### PR TITLE
To export non-log10 data when plot (X/Y) Axis Spacing is set to Log10…

### DIFF
--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
@@ -2,14 +2,12 @@
 using OxyPlot.Legends;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Numerics;
 using System.Threading;
-using Microsoft.Win32;
+using System.Windows;
 using Vts.Common;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.ViewModel;
-using Point = System.Windows.Point;
 
 namespace Vts.Gui.Wpf.Test.ViewModel.Panels
 {
@@ -175,7 +173,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             Assert.AreEqual("", viewModel.CustomPlotLabel);
             Assert.AreEqual(ReflectancePlotType.ForwardSolver, viewModel.PlotType);
             Assert.AreEqual("", viewModel.PlotModel.Title);
-            Assert.AreEqual(LegendPlacement.Outside, viewModel.PlotModel.Legends[0].LegendPlacement);
+            Assert.AreEqual(viewModel.PlotModel.Legends[0].LegendPlacement, LegendPlacement.Outside);
         }
 
         // The following tests verify the Relay Commands
@@ -578,33 +576,13 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Assert.IsInstanceOf<Point>(point);
                 i++;
             }
-
             Assert.AreEqual(10, i);
         }
-
-
-        //[Test]
-        //public void Verify_ExportDataToText_correct_when_X_andor_Y_scaling_set_to_log()
-        //{
-        //    var points = new[]
-        //    {
-        //        new Point(1, 1),
-        //        new Point(2, 2),
-        //        new Point(3, 3),
-        //        new Point(4, 4),
-        //        new Point(5, 5),
-        //        new Point(6, 6),
-        //    };
-        //    _plotData = new[] { new PlotData(points, "Diagonal Line") };
-        //    _plotViewModel = new PlotViewModel();
-        //    _plotViewModel.PlotValues.Execute(_plotData);
-        //    //var openFileDialogMock = Substitute.For<OpenFileDialog>();
-
-        //}
 
         /// <summary>
         /// ExportDataToTextCommand brings up Dialog window so not tested
         /// DuplicateWindowCommand - not sure if can test 
         /// </summary>
+
     }
 }

--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
@@ -3,16 +3,15 @@ using OxyPlot.Legends;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Reflection;
 using System.Threading;
 using System.Windows;
-using Microsoft.Win32;
+using System.Windows.Forms;
+using System.Windows.Input;
 using NSubstitute;
 using Vts.Common;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.ViewModel;
-using System.IO;
-using System.Reflection;
-using System.Windows.Input;
 
 namespace Vts.Gui.Wpf.Test.ViewModel.Panels
 {
@@ -584,18 +583,18 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             _plotViewModel.PlotValues.Execute(_plotData);
 
             // mock the SaveFileDialog
+            var saveFileDialogMock = Substitute.For<ISaveFileDialog>();
+            const string exportFileName = "testexportdata.txt";
+            saveFileDialogMock.FileName.Returns(exportFileName);
+            saveFileDialogMock.ShowDialog().Returns(false);
+            
+
             //var saveFileDialogMock = Substitute.For<ISaveFileDialog>();
             //const string exportFileName = "testexportdata.txt";
             //saveFileDialogMock.FileName.Returns(exportFileName);
-            //saveFileDialogMock.ShowDialog().Returns(true);
+            //saveFileDialogMock.ShowDialog().Returns(false);
             //_plotViewModel.ExportDataToTextCommand.Execute(_plotData);
 
-            // try another way
-            //var executedRoutedEventArgsMock = Substitute.For<ISaveFileDialog>();
-            //var mockArgs = Activator.CreateInstance(
-            //    typeof(ExecutedRoutedEventArgs), BindingFlags.NonPublic,
-            //    BindingFlags.Instance, saveFileDialogMock );
-            //_plotViewModel.ExportDataToTextCommand.Execute(_plotData, mockArgs);
 
             //// verify results in file
             //var stream = new FileStream(exportFileName, FileMode.Create);

--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
@@ -2,12 +2,14 @@
 using OxyPlot.Legends;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Numerics;
 using System.Threading;
-using System.Windows;
+using Microsoft.Win32;
 using Vts.Common;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.ViewModel;
+using Point = System.Windows.Point;
 
 namespace Vts.Gui.Wpf.Test.ViewModel.Panels
 {
@@ -25,7 +27,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Title = "Title",
                 DataPoints = new IDataPoint[]
                 {
-                    new DoubleDataPoint(0, 0), 
+                    new DoubleDataPoint(0, 0),
                     new DoubleDataPoint(1, 1)
                 },
                 ColorTag = "HSV"
@@ -57,8 +59,8 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             {
                 new[]
                 {
-                    new Point(0, 0), 
-                    new Point(1, 1), 
+                    new Point(0, 0),
+                    new Point(1, 1),
                     new Point(3, 3)
                 },
                 new[]
@@ -68,9 +70,9 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                     new Point(3.5, 3.5)
                 },
             };
-            var colorTags = new List<string> {"red", "white"};
+            var colorTags = new List<string> { "red", "white" };
             var plotPointCollection = new PlotPointCollection(points, colorTags);
-            Assert.AreEqual("white",plotPointCollection.ColorTags[1]);
+            Assert.AreEqual("white", plotPointCollection.ColorTags[1]);
             Assert.AreEqual(2, plotPointCollection.Count);
         }
 
@@ -173,7 +175,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             Assert.AreEqual("", viewModel.CustomPlotLabel);
             Assert.AreEqual(ReflectancePlotType.ForwardSolver, viewModel.PlotType);
             Assert.AreEqual("", viewModel.PlotModel.Title);
-            Assert.AreEqual(viewModel.PlotModel.Legends[0].LegendPlacement, LegendPlacement.Outside);
+            Assert.AreEqual(LegendPlacement.Outside, viewModel.PlotModel.Legends[0].LegendPlacement);
         }
 
         // The following tests verify the Relay Commands
@@ -203,24 +205,30 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
         public void Verify_SetAxesLabelsCommand_returns_correct_values()
         {
             var viewModel = new PlotViewModel();
-            var labels = new PlotAxesLabels("dependent", "units", 
-                new IndependentAxisViewModel 
+            var labels = new PlotAxesLabels("dependent", "units",
+                new IndependentAxisViewModel
                 {
                     AxisLabel = "independent",
-                    AxisRangeVM = new RangeViewModel(new DoubleRange(0.5, 9.5, 19), "mm", IndependentVariableAxis.Rho, "Detector Positions"),
+                    AxisRangeVM = new RangeViewModel(new DoubleRange(0.5, 9.5, 19), "mm", IndependentVariableAxis.Rho,
+                        "Detector Positions"),
                     AxisType = IndependentVariableAxis.Rho,
                     AxisUnits = "units"
-                }, 
-                new[] { new ConstantAxisViewModel
+                },
+                new[]
                 {
-                    AxisLabel = "t",
-                    AxisType = IndependentVariableAxis.Time,
-                    AxisUnits = "ns",
-                    AxisValue = 0.05,
-                    ImageHeight = 1
-                }});
+                    new ConstantAxisViewModel
+                    {
+                        AxisLabel = "t",
+                        AxisType = IndependentVariableAxis.Time,
+                        AxisUnits = "ns",
+                        AxisValue = 0.05,
+                        ImageHeight = 1
+                    }
+                });
             viewModel.SetAxesLabels.Execute(labels);
-            Assert.AreEqual($"dependent [units] versus independent [units] at t = {0.05.ToString(Thread.CurrentThread.CurrentCulture)} ns", viewModel.Title);
+            Assert.AreEqual(
+                $"dependent [units] versus independent [units] at t = {0.05.ToString(Thread.CurrentThread.CurrentCulture)} ns",
+                viewModel.Title);
             var constantAxes = new[]
             {
                 new ConstantAxisViewModel
@@ -242,7 +250,9 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             };
             labels.ConstantAxes = constantAxes;
             viewModel.SetAxesLabels.Execute(labels);
-            Assert.AreEqual($"dependent [units] versus independent [units] at t = {0.05.ToString(Thread.CurrentThread.CurrentCulture)} ns and z = {0.1.ToString(Thread.CurrentThread.CurrentCulture)} mm", viewModel.Title);
+            Assert.AreEqual(
+                $"dependent [units] versus independent [units] at t = {0.05.ToString(Thread.CurrentThread.CurrentCulture)} ns and z = {0.1.ToString(Thread.CurrentThread.CurrentCulture)} mm",
+                viewModel.Title);
         }
 
         // The following tests verify the Relay Commands
@@ -335,10 +345,14 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
 
             Assert.AreEqual(viewModel.CurrentIndependentVariableAxis, viewModelClone.CurrentIndependentVariableAxis);
 
-            Assert.IsTrue(viewModelClone.PlotNormalizationTypeOptionVm.Options[viewModelClone.PlotNormalizationTypeOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.PlotToggleTypeOptionVm.Options[viewModelClone.PlotToggleTypeOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.XAxisSpacingOptionVm.Options[viewModelClone.XAxisSpacingOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.YAxisSpacingOptionVm.Options[viewModelClone.YAxisSpacingOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.PlotNormalizationTypeOptionVm
+                .Options[viewModelClone.PlotNormalizationTypeOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.PlotToggleTypeOptionVm
+                .Options[viewModelClone.PlotToggleTypeOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.XAxisSpacingOptionVm.Options[viewModelClone.XAxisSpacingOptionVm.SelectedValue]
+                .IsSelected);
+            Assert.IsTrue(viewModelClone.YAxisSpacingOptionVm.Options[viewModelClone.YAxisSpacingOptionVm.SelectedValue]
+                .IsSelected);
         }
 
         [Test]
@@ -369,12 +383,17 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             Assert.AreEqual(_plotViewModel.AutoScaleX, viewModelClone.AutoScaleX);
             Assert.AreEqual(_plotViewModel.AutoScaleY, viewModelClone.AutoScaleY);
 
-            Assert.AreEqual(_plotViewModel.CurrentIndependentVariableAxis, viewModelClone.CurrentIndependentVariableAxis);
+            Assert.AreEqual(_plotViewModel.CurrentIndependentVariableAxis,
+                viewModelClone.CurrentIndependentVariableAxis);
 
-            Assert.IsTrue(viewModelClone.PlotNormalizationTypeOptionVm.Options[viewModelClone.PlotNormalizationTypeOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.PlotToggleTypeOptionVm.Options[viewModelClone.PlotToggleTypeOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.XAxisSpacingOptionVm.Options[viewModelClone.XAxisSpacingOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.YAxisSpacingOptionVm.Options[viewModelClone.YAxisSpacingOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.PlotNormalizationTypeOptionVm
+                .Options[viewModelClone.PlotNormalizationTypeOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.PlotToggleTypeOptionVm
+                .Options[viewModelClone.PlotToggleTypeOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.XAxisSpacingOptionVm.Options[viewModelClone.XAxisSpacingOptionVm.SelectedValue]
+                .IsSelected);
+            Assert.IsTrue(viewModelClone.YAxisSpacingOptionVm.Options[viewModelClone.YAxisSpacingOptionVm.SelectedValue]
+                .IsSelected);
         }
 
         [Test]
@@ -428,7 +447,8 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
         [Test]
         public void Verify_complex_plot()
         {
-            IDataPoint[] points = {
+            IDataPoint[] points =
+            {
                 new ComplexDataPoint(0, new Complex(0, 1)),
                 new ComplexDataPoint(1, new Complex(1, 2)),
                 new ComplexDataPoint(2, new Complex(2, 3)),
@@ -470,6 +490,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Assert.IsInstanceOf<Point>(point);
                 i++;
             }
+
             Assert.AreEqual(10, i);
         }
 
@@ -489,13 +510,15 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Assert.IsInstanceOf<Point>(point);
                 i++;
             }
+
             Assert.AreEqual(10, i);
         }
 
         [Test]
         public void Verify_max_normalization_complex()
         {
-            IDataPoint[] points = {
+            IDataPoint[] points =
+            {
                 new ComplexDataPoint(0, new Complex(0, 1)),
                 new ComplexDataPoint(1, new Complex(1, 2)),
                 new ComplexDataPoint(2, new Complex(2, 3)),
@@ -521,13 +544,15 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Assert.IsInstanceOf<Point>(point);
                 i++;
             }
+
             Assert.AreEqual(10, i);
         }
 
         [Test]
         public void Verify_curve_normalization_complex()
         {
-            IDataPoint[] points = {
+            IDataPoint[] points =
+            {
                 new ComplexDataPoint(2, new Complex(5, 1)),
                 new ComplexDataPoint(1, new Complex(1, 2)),
                 new ComplexDataPoint(2, new Complex(2, 3)),
@@ -553,13 +578,33 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Assert.IsInstanceOf<Point>(point);
                 i++;
             }
+
             Assert.AreEqual(10, i);
         }
+
+
+        //[Test]
+        //public void Verify_ExportDataToText_correct_when_X_andor_Y_scaling_set_to_log()
+        //{
+        //    var points = new[]
+        //    {
+        //        new Point(1, 1),
+        //        new Point(2, 2),
+        //        new Point(3, 3),
+        //        new Point(4, 4),
+        //        new Point(5, 5),
+        //        new Point(6, 6),
+        //    };
+        //    _plotData = new[] { new PlotData(points, "Diagonal Line") };
+        //    _plotViewModel = new PlotViewModel();
+        //    _plotViewModel.PlotValues.Execute(_plotData);
+        //    //var openFileDialogMock = Substitute.For<OpenFileDialog>();
+
+        //}
 
         /// <summary>
         /// ExportDataToTextCommand brings up Dialog window so not tested
         /// DuplicateWindowCommand - not sure if can test 
         /// </summary>
-
     }
 }

--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
@@ -603,7 +603,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 new Point(6, 6),
             };
             // plot the data to be saved
-            _plotData = new[] { new PlotData(points, "Diagonal Line") };
+            var plotData = new[] { new PlotData(points, "Diagonal Line") };
             // can't call WindowViewModel because not fixed yet
             //var windowViewModel = new WindowViewModel();
             //var plotViewModel = windowViewModel.PlotVM;
@@ -618,10 +618,10 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             fileSystemMock.WriteExportedData(exportFilename, Encoding.UTF8);
 
             _plotViewModel = new PlotViewModel(0, openFileDialogMock, fileSystemMock);
-            _plotViewModel.PlotValues.Execute(_plotData);
+            _plotViewModel.PlotValues.Execute(plotData);
             _plotViewModel.XAxisSpacingOptionVm.SelectedValue = ScalingType.Log;
             _plotViewModel.YAxisSpacingOptionVm.SelectedValue = ScalingType.Log;
-            _plotViewModel.ExportDataToTextCommand.Execute(_plotData);
+            _plotViewModel.ExportDataToTextCommand.Execute(plotData);
 
             // verify results in file
             var stream = new FileStream(exportFilename, FileMode.Open);
@@ -665,7 +665,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 new ComplexDataPoint(6, new Complex(6, 6)),
             };
             // plot the data to be saved
-            _plotData = new[] { new PlotData(points, "Real and Imaginary Lines") };
+            var plotData = new[] { new PlotData(points, "Real and Imaginary Lines") };
 
             // mock the IOpenFileDialog
             var openFileDialogMock = Substitute.For<PlotViewModel.IOpenFileDialog>();
@@ -676,9 +676,9 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             fileSystemMock.WriteExportedData(exportFilename, Encoding.UTF8);
 
             _plotViewModel = new PlotViewModel(0, openFileDialogMock, fileSystemMock);
-            _plotViewModel.PlotValues.Execute(_plotData);
+            _plotViewModel.PlotValues.Execute(plotData);
             _plotViewModel.PlotToggleTypeOptionVm.SelectedValue = PlotToggleType.Amp;
-            _plotViewModel.ExportDataToTextCommand.Execute(_plotData);
+            _plotViewModel.ExportDataToTextCommand.Execute(plotData);
 
             // verify results in file
             var stream = new FileStream(exportFilename, FileMode.Open);

--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
@@ -610,14 +610,14 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             //plotViewModel.PlotValues.Execute(_plotData);
 
             // mock the IOpenFileDialog
-            var openFileDialogMock = Substitute.For<PlotViewModel.IOpenFileDialog>();
+            var openFileDialogMock = Substitute.For<PlotViewModel.ISaveFileDialog>();
             openFileDialogMock.FileName.Returns(exportFilename);
             openFileDialogMock.ShowDialog().Returns(true);
             // mock IFileSystem
             var fileSystemMock = Substitute.For<PlotViewModel.IFileSystem>();
             fileSystemMock.WriteExportedData(exportFilename, Encoding.UTF8);
 
-            _plotViewModel = new PlotViewModel(0, openFileDialogMock, fileSystemMock);
+            _plotViewModel = new PlotViewModel(0, openFileDialogMock);
             _plotViewModel.PlotValues.Execute(plotData);
             _plotViewModel.XAxisSpacingOptionVm.SelectedValue = ScalingType.Log;
             _plotViewModel.YAxisSpacingOptionVm.SelectedValue = ScalingType.Log;
@@ -668,14 +668,14 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             var plotData = new[] { new PlotData(points, "Real and Imaginary Lines") };
 
             // mock the IOpenFileDialog
-            var openFileDialogMock = Substitute.For<PlotViewModel.IOpenFileDialog>();
+            var openFileDialogMock = Substitute.For<PlotViewModel.ISaveFileDialog>();
             openFileDialogMock.FileName.Returns(exportFilename);
             openFileDialogMock.ShowDialog().Returns(true);
             // mock IFileSystem
             var fileSystemMock = Substitute.For<PlotViewModel.IFileSystem>();
             fileSystemMock.WriteExportedData(exportFilename, Encoding.UTF8);
 
-            _plotViewModel = new PlotViewModel(0, openFileDialogMock, fileSystemMock);
+            _plotViewModel = new PlotViewModel(0, openFileDialogMock);
             _plotViewModel.PlotValues.Execute(plotData);
             _plotViewModel.PlotToggleTypeOptionVm.SelectedValue = PlotToggleType.Amp;
             _plotViewModel.ExportDataToTextCommand.Execute(plotData);

--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading;
 using System.Windows;
 using Vts.Common;
+using Vts.Gui.Wpf.FileSystem;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.ViewModel;
 using Vts.IO;
@@ -610,12 +611,9 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             //plotViewModel.PlotValues.Execute(_plotData);
 
             // mock the IOpenFileDialog
-            var openFileDialogMock = Substitute.For<PlotViewModel.ISaveFileDialog>();
+            var openFileDialogMock = Substitute.For<ISaveFileDialog>();
             openFileDialogMock.FileName.Returns(exportFilename);
             openFileDialogMock.ShowDialog().Returns(true);
-            // mock IFileSystem
-            var fileSystemMock = Substitute.For<PlotViewModel.IFileSystem>();
-            fileSystemMock.WriteExportedData(exportFilename, Encoding.UTF8);
 
             _plotViewModel = new PlotViewModel(0, openFileDialogMock);
             _plotViewModel.PlotValues.Execute(plotData);
@@ -668,12 +666,9 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             var plotData = new[] { new PlotData(points, "Real and Imaginary Lines") };
 
             // mock the IOpenFileDialog
-            var openFileDialogMock = Substitute.For<PlotViewModel.ISaveFileDialog>();
+            var openFileDialogMock = Substitute.For<ISaveFileDialog>();
             openFileDialogMock.FileName.Returns(exportFilename);
             openFileDialogMock.ShowDialog().Returns(true);
-            // mock IFileSystem
-            var fileSystemMock = Substitute.For<PlotViewModel.IFileSystem>();
-            fileSystemMock.WriteExportedData(exportFilename, Encoding.UTF8);
 
             _plotViewModel = new PlotViewModel(0, openFileDialogMock);
             _plotViewModel.PlotValues.Execute(plotData);

--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
@@ -5,9 +5,12 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Threading;
 using System.Windows;
+using Microsoft.Win32;
+using NSubstitute;
 using Vts.Common;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.ViewModel;
+using System.IO;
 
 namespace Vts.Gui.Wpf.Test.ViewModel.Panels
 {
@@ -25,7 +28,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Title = "Title",
                 DataPoints = new IDataPoint[]
                 {
-                    new DoubleDataPoint(0, 0),
+                    new DoubleDataPoint(0, 0), 
                     new DoubleDataPoint(1, 1)
                 },
                 ColorTag = "HSV"
@@ -57,8 +60,8 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             {
                 new[]
                 {
-                    new Point(0, 0),
-                    new Point(1, 1),
+                    new Point(0, 0), 
+                    new Point(1, 1), 
                     new Point(3, 3)
                 },
                 new[]
@@ -68,9 +71,9 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                     new Point(3.5, 3.5)
                 },
             };
-            var colorTags = new List<string> { "red", "white" };
+            var colorTags = new List<string> {"red", "white"};
             var plotPointCollection = new PlotPointCollection(points, colorTags);
-            Assert.AreEqual("white", plotPointCollection.ColorTags[1]);
+            Assert.AreEqual("white",plotPointCollection.ColorTags[1]);
             Assert.AreEqual(2, plotPointCollection.Count);
         }
 
@@ -203,30 +206,24 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
         public void Verify_SetAxesLabelsCommand_returns_correct_values()
         {
             var viewModel = new PlotViewModel();
-            var labels = new PlotAxesLabels("dependent", "units",
-                new IndependentAxisViewModel
+            var labels = new PlotAxesLabels("dependent", "units", 
+                new IndependentAxisViewModel 
                 {
                     AxisLabel = "independent",
-                    AxisRangeVM = new RangeViewModel(new DoubleRange(0.5, 9.5, 19), "mm", IndependentVariableAxis.Rho,
-                        "Detector Positions"),
+                    AxisRangeVM = new RangeViewModel(new DoubleRange(0.5, 9.5, 19), "mm", IndependentVariableAxis.Rho, "Detector Positions"),
                     AxisType = IndependentVariableAxis.Rho,
                     AxisUnits = "units"
-                },
-                new[]
+                }, 
+                new[] { new ConstantAxisViewModel
                 {
-                    new ConstantAxisViewModel
-                    {
-                        AxisLabel = "t",
-                        AxisType = IndependentVariableAxis.Time,
-                        AxisUnits = "ns",
-                        AxisValue = 0.05,
-                        ImageHeight = 1
-                    }
-                });
+                    AxisLabel = "t",
+                    AxisType = IndependentVariableAxis.Time,
+                    AxisUnits = "ns",
+                    AxisValue = 0.05,
+                    ImageHeight = 1
+                }});
             viewModel.SetAxesLabels.Execute(labels);
-            Assert.AreEqual(
-                $"dependent [units] versus independent [units] at t = {0.05.ToString(Thread.CurrentThread.CurrentCulture)} ns",
-                viewModel.Title);
+            Assert.AreEqual($"dependent [units] versus independent [units] at t = {0.05.ToString(Thread.CurrentThread.CurrentCulture)} ns", viewModel.Title);
             var constantAxes = new[]
             {
                 new ConstantAxisViewModel
@@ -248,9 +245,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             };
             labels.ConstantAxes = constantAxes;
             viewModel.SetAxesLabels.Execute(labels);
-            Assert.AreEqual(
-                $"dependent [units] versus independent [units] at t = {0.05.ToString(Thread.CurrentThread.CurrentCulture)} ns and z = {0.1.ToString(Thread.CurrentThread.CurrentCulture)} mm",
-                viewModel.Title);
+            Assert.AreEqual($"dependent [units] versus independent [units] at t = {0.05.ToString(Thread.CurrentThread.CurrentCulture)} ns and z = {0.1.ToString(Thread.CurrentThread.CurrentCulture)} mm", viewModel.Title);
         }
 
         // The following tests verify the Relay Commands
@@ -343,14 +338,10 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
 
             Assert.AreEqual(viewModel.CurrentIndependentVariableAxis, viewModelClone.CurrentIndependentVariableAxis);
 
-            Assert.IsTrue(viewModelClone.PlotNormalizationTypeOptionVm
-                .Options[viewModelClone.PlotNormalizationTypeOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.PlotToggleTypeOptionVm
-                .Options[viewModelClone.PlotToggleTypeOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.XAxisSpacingOptionVm.Options[viewModelClone.XAxisSpacingOptionVm.SelectedValue]
-                .IsSelected);
-            Assert.IsTrue(viewModelClone.YAxisSpacingOptionVm.Options[viewModelClone.YAxisSpacingOptionVm.SelectedValue]
-                .IsSelected);
+            Assert.IsTrue(viewModelClone.PlotNormalizationTypeOptionVm.Options[viewModelClone.PlotNormalizationTypeOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.PlotToggleTypeOptionVm.Options[viewModelClone.PlotToggleTypeOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.XAxisSpacingOptionVm.Options[viewModelClone.XAxisSpacingOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.YAxisSpacingOptionVm.Options[viewModelClone.YAxisSpacingOptionVm.SelectedValue].IsSelected);
         }
 
         [Test]
@@ -381,17 +372,12 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             Assert.AreEqual(_plotViewModel.AutoScaleX, viewModelClone.AutoScaleX);
             Assert.AreEqual(_plotViewModel.AutoScaleY, viewModelClone.AutoScaleY);
 
-            Assert.AreEqual(_plotViewModel.CurrentIndependentVariableAxis,
-                viewModelClone.CurrentIndependentVariableAxis);
+            Assert.AreEqual(_plotViewModel.CurrentIndependentVariableAxis, viewModelClone.CurrentIndependentVariableAxis);
 
-            Assert.IsTrue(viewModelClone.PlotNormalizationTypeOptionVm
-                .Options[viewModelClone.PlotNormalizationTypeOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.PlotToggleTypeOptionVm
-                .Options[viewModelClone.PlotToggleTypeOptionVm.SelectedValue].IsSelected);
-            Assert.IsTrue(viewModelClone.XAxisSpacingOptionVm.Options[viewModelClone.XAxisSpacingOptionVm.SelectedValue]
-                .IsSelected);
-            Assert.IsTrue(viewModelClone.YAxisSpacingOptionVm.Options[viewModelClone.YAxisSpacingOptionVm.SelectedValue]
-                .IsSelected);
+            Assert.IsTrue(viewModelClone.PlotNormalizationTypeOptionVm.Options[viewModelClone.PlotNormalizationTypeOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.PlotToggleTypeOptionVm.Options[viewModelClone.PlotToggleTypeOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.XAxisSpacingOptionVm.Options[viewModelClone.XAxisSpacingOptionVm.SelectedValue].IsSelected);
+            Assert.IsTrue(viewModelClone.YAxisSpacingOptionVm.Options[viewModelClone.YAxisSpacingOptionVm.SelectedValue].IsSelected);
         }
 
         [Test]
@@ -445,8 +431,7 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
         [Test]
         public void Verify_complex_plot()
         {
-            IDataPoint[] points =
-            {
+            IDataPoint[] points = {
                 new ComplexDataPoint(0, new Complex(0, 1)),
                 new ComplexDataPoint(1, new Complex(1, 2)),
                 new ComplexDataPoint(2, new Complex(2, 3)),
@@ -488,7 +473,6 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Assert.IsInstanceOf<Point>(point);
                 i++;
             }
-
             Assert.AreEqual(10, i);
         }
 
@@ -508,15 +492,13 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Assert.IsInstanceOf<Point>(point);
                 i++;
             }
-
             Assert.AreEqual(10, i);
         }
 
         [Test]
         public void Verify_max_normalization_complex()
         {
-            IDataPoint[] points =
-            {
+            IDataPoint[] points = {
                 new ComplexDataPoint(0, new Complex(0, 1)),
                 new ComplexDataPoint(1, new Complex(1, 2)),
                 new ComplexDataPoint(2, new Complex(2, 3)),
@@ -542,15 +524,13 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
                 Assert.IsInstanceOf<Point>(point);
                 i++;
             }
-
             Assert.AreEqual(10, i);
         }
 
         [Test]
         public void Verify_curve_normalization_complex()
         {
-            IDataPoint[] points =
-            {
+            IDataPoint[] points = {
                 new ComplexDataPoint(2, new Complex(5, 1)),
                 new ComplexDataPoint(1, new Complex(1, 2)),
                 new ComplexDataPoint(2, new Complex(2, 3)),
@@ -583,6 +563,42 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
         /// ExportDataToTextCommand brings up Dialog window so not tested
         /// DuplicateWindowCommand - not sure if can test 
         /// </summary>
+
+        [Test]
+        public void Verify_ExportDataToText_correct_when_X_andor_Y_scaling_set_to_log()
+        {
+            var points = new[]
+            {
+                new Point(1, 1),
+                new Point(2, 2),
+                new Point(3, 3),
+                new Point(4, 4),
+                new Point(5, 5),
+                new Point(6, 6),
+            };
+            // plot the data to be saved
+            _plotData = new[] { new PlotData(points, "Diagonal Line") };
+            _plotViewModel = new PlotViewModel();
+
+            //// mock the SaveFileDialog
+            //var saveFileDialogMock = Substitute.For<SaveFileDialog>();
+            //const string exportFileName = "testexportdata.txt";
+            //saveFileDialogMock.FileName = exportFileName;
+            //saveFileDialogMock.ShowDialog() = true;
+            //_plotViewModel.PlotValues.Execute(_plotData);
+
+            //// verify results in file
+            //var stream = new FileStream(exportFileName, FileMode.Create);
+            //using var sw = new StreamReader(stream);
+            //var line = sw.ReadLine(); // this has to skip header
+            //var data = line.Split();
+        }
+
+        public interface ISaveFileDialog
+        {
+            bool? ShowDialog();
+            string FileName { get; set; }
+        }
 
     }
 }

--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/PlotViewModelTests.cs
@@ -11,6 +11,8 @@ using Vts.Common;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.ViewModel;
 using System.IO;
+using System.Reflection;
+using System.Windows.Input;
 
 namespace Vts.Gui.Wpf.Test.ViewModel.Panels
 {
@@ -579,13 +581,21 @@ namespace Vts.Gui.Wpf.Test.ViewModel.Panels
             // plot the data to be saved
             _plotData = new[] { new PlotData(points, "Diagonal Line") };
             _plotViewModel = new PlotViewModel();
+            _plotViewModel.PlotValues.Execute(_plotData);
 
-            //// mock the SaveFileDialog
-            //var saveFileDialogMock = Substitute.For<SaveFileDialog>();
+            // mock the SaveFileDialog
+            //var saveFileDialogMock = Substitute.For<ISaveFileDialog>();
             //const string exportFileName = "testexportdata.txt";
-            //saveFileDialogMock.FileName = exportFileName;
-            //saveFileDialogMock.ShowDialog() = true;
-            //_plotViewModel.PlotValues.Execute(_plotData);
+            //saveFileDialogMock.FileName.Returns(exportFileName);
+            //saveFileDialogMock.ShowDialog().Returns(true);
+            //_plotViewModel.ExportDataToTextCommand.Execute(_plotData);
+
+            // try another way
+            //var executedRoutedEventArgsMock = Substitute.For<ISaveFileDialog>();
+            //var mockArgs = Activator.CreateInstance(
+            //    typeof(ExecutedRoutedEventArgs), BindingFlags.NonPublic,
+            //    BindingFlags.Instance, saveFileDialogMock );
+            //_plotViewModel.ExportDataToTextCommand.Execute(_plotData, mockArgs);
 
             //// verify results in file
             //var stream = new FileStream(exportFileName, FileMode.Create);

--- a/Vts.Gui.Wpf.Test/Vts.Gui.Wpf.Test.csproj
+++ b/Vts.Gui.Wpf.Test/Vts.Gui.Wpf.Test.csproj
@@ -9,6 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.5" />
+		<PackageReference Include="NSubstitute" Version="5.1.0" />
 		<PackageReference Include="NUnit" Version="3.14.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<PackageReference Include="VirtualPhotonics.Vts" Version="10.0.0" />

--- a/Vts.Gui.Wpf/FileSystem/ISaveFileDialog.cs
+++ b/Vts.Gui.Wpf/FileSystem/ISaveFileDialog.cs
@@ -1,0 +1,10 @@
+﻿namespace Vts.Gui.Wpf.FileSystem
+{
+    public interface ISaveFileDialog
+    {
+        string Filter { get; set; }
+        bool? ShowDialog();
+        string FileName { get; set; }
+        string DefaultExtension { get; set; }
+    }
+}

--- a/Vts.Gui.Wpf/FileSystem/ITextFileService.cs
+++ b/Vts.Gui.Wpf/FileSystem/ITextFileService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.IO;
+
+namespace Vts.Gui.Wpf.FileSystem
+{
+    public interface ITextFileService
+    {
+        public Tuple<FileStream, string> OpenTextFile();
+    }
+}

--- a/Vts.Gui.Wpf/FileSystem/SaveFileDialog.cs
+++ b/Vts.Gui.Wpf/FileSystem/SaveFileDialog.cs
@@ -1,0 +1,21 @@
+﻿namespace Vts.Gui.Wpf.FileSystem
+{
+    public class SaveFileDialog : ISaveFileDialog
+    {
+        public string Filter { get; set; }
+        public bool? ShowDialog()
+        {
+            var dialog = new Microsoft.Win32.SaveFileDialog
+            { 
+                DefaultExt = DefaultExtension ?? ".txt",
+                Filter = Filter
+            };
+            var result = dialog.ShowDialog();
+            FileName = dialog.FileName;
+            return result;
+        }
+
+        public string FileName { get; set; }
+        public string DefaultExtension { get; set; }
+    }
+}

--- a/Vts.Gui.Wpf/Model/IDataPoint.cs
+++ b/Vts.Gui.Wpf/Model/IDataPoint.cs
@@ -2,6 +2,6 @@
 {
     public interface IDataPoint
     {
-        double X { get; set; }
+        double X { get; set; }  // only X here to work for both Double and Complex points
     }
 }

--- a/Vts.Gui.Wpf/Resources/Strings.Designer.cs
+++ b/Vts.Gui.Wpf/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Vts.Gui.Wpf.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -115,7 +115,7 @@ namespace Vts.Gui.Wpf.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Export Data.
+        ///   Looks up a localized string similar to Export Raw Data.
         /// </summary>
         public static string Button_ExportData {
             get {

--- a/Vts.Gui.Wpf/Resources/Strings.resx
+++ b/Vts.Gui.Wpf/Resources/Strings.resx
@@ -283,7 +283,7 @@
     <value>Clear Newest</value>
   </data>
   <data name="Button_ExportData" xml:space="preserve">
-    <value>Export Data</value>
+    <value>Export Raw Data</value>
   </data>
   <data name="Button_ExportImage" xml:space="preserve">
     <value>Export As Image</value>

--- a/Vts.Gui.Wpf/ViewModel/Panels/FluenceSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/FluenceSolverViewModel.cs
@@ -358,7 +358,7 @@ namespace Vts.Gui.Wpf.ViewModel
                 {
                     await GetMapData();
                 }
-                catch (System.ArgumentException ex)
+                catch (ArgumentException ex)
                 {
                     WindowViewModel.Current.TextOutputVM.TextOutput_PostMessage.Execute(
                         StringLookup.GetLocalizedString("Label_FluenceSolver\r"));

--- a/Vts.Gui.Wpf/ViewModel/Panels/ForwardSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/ForwardSolverViewModel.cs
@@ -320,7 +320,7 @@ namespace Vts.Gui.Wpf.ViewModel
                 WindowViewModel.Current.TextOutputVM.TextOutput_PostMessage.Execute(
                     StringLookup.GetLocalizedString("Label_ForwardSolver") + TissueInputVM + "\r");
             }
-            catch (System.ArgumentException ex)
+            catch (ArgumentException ex)
             {
                 WindowViewModel.Current.TextOutputVM.TextOutput_PostMessage.Execute(
                     StringLookup.GetLocalizedString("Label_ForwardSolver\r"));

--- a/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
@@ -111,8 +111,8 @@ namespace Vts.Gui.Wpf.ViewModel
             
             Labels = new List<string>();
             PlotTitles = new List<string>();
-            DataSeriesCollection = new List<DataPointCollection>();
-            PlotSeriesCollection = new PlotPointCollection();
+            DataSeriesCollection = new List<DataPointCollection>(); // raw data
+            PlotSeriesCollection = new PlotPointCollection(); // raw data manipulated by the user toggles
 
             PlotModel = new PlotModel
             {
@@ -569,10 +569,10 @@ namespace Vts.Gui.Wpf.ViewModel
         /// <param name="e"></param>
         private void Plot_ExportDataToText_Executed(object sender, ExecutedRoutedEventArgs e)
         {
-            if (_labels != null && _labels.Count > 0 && _plotSeriesCollection != null && _plotSeriesCollection.Count > 0)
+            if (_labels != null && _labels.Count > 0 && DataSeriesCollection != null && DataSeriesCollection.Count > 0)
             {
-                // Create SaveFileDialog 
-                var dialog = new SaveFileDialog
+                    // Create SaveFileDialog 
+                    var dialog = new SaveFileDialog
                 {
                     DefaultExt = ".txt",
                     Filter = "Text Files (*.txt)|*.txt"
@@ -595,29 +595,12 @@ namespace Vts.Gui.Wpf.ViewModel
                     sw.Write("%");
                     _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Y)" + "\t"));
                     sw.WriteLine();
-                    for (var i = 0; i < _plotSeriesCollection[0].Length; i++)
+                    for (var i = 0; i < DataSeriesCollection.Count - 1; i++)
                     {
-                        sw.WriteLine();
+                            sw.WriteLine();
                         foreach (var t in _plotSeriesCollection)
                         {
-                            // check if user selected (X/Y) Axis Scaled to Log10 and if so
-                            // make sure un-log10 data is written to file
-                            if (XAxisSpacingOptionVm.SelectedValue == ScalingType.Log)
-                            {
-                                sw.Write(Math.Pow(10, t[i].X) + "\t");
-                            }
-                            else
-                            {
-                                sw.Write(t[i].X + "\t");
-                            }
-                            if (YAxisSpacingOptionVm.SelectedValue == ScalingType.Log)
-                            {
-                                sw.Write(Math.Pow(10, t[i].Y) + "\t");
-                            }
-                            else
-                            {
-                                sw.Write(t[i].Y + "\t");
-                            }
+                            sw.Write(t[i].X + "\t" + t[i].Y + "\t");
                         }
                     }
                 }

--- a/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
@@ -600,6 +600,8 @@ namespace Vts.Gui.Wpf.ViewModel
                         sw.WriteLine();
                         foreach (var t in _plotSeriesCollection)
                         {
+                            // check if user selected (X/Y) Axis Scaled to Log10 and if so
+                            // make sure un-log10 data is written to file
                             if (XAxisSpacingOptionVm.SelectedValue == ScalingType.Log)
                             {
                                 sw.Write(Math.Pow(10, t[i].X) + "\t");

--- a/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
@@ -593,14 +593,25 @@ namespace Vts.Gui.Wpf.ViewModel
             var stream = new FileStream(filename, FileMode.Create);
             using var sw = new StreamWriter(stream);
             sw.Write("%");
+
             if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
             {
-                _labels.ForEach(label => sw.WriteLine(label + " (X)" + "\t" + " (Y)" + "\t"));
-                sw.WriteLine("%");
+                for (var i = 0; i < _labels.Count; i++)
+                {
+                    sw.Write(PlotTitles[i]);
+                    sw.WriteLine(_labels[i] + " (X)" + "\t" + _labels[i] + " (Y)" + "\t\n");
+                }
+                //_labels.ForEach(label => sw.WriteLine(label + " (X)" + "\t" + " (Y)" + "\t"));
             }
             else // ComplexDataPoint
             {
-                _labels.ForEach(label => sw.WriteLine(label + " (X)" + "\t" + label + " (Real)" + "\t" + " (Imag)" + "\t"));
+                // output plot titles and labels together
+                for (var i = 0; i < _labels.Count; i++)
+                {
+                    sw.Write(PlotTitles[i]);
+                    sw.WriteLine(_labels[i] + " (X)" + "\t" + _labels[i] + " (Real)" + "\t" + " (Imag)" + "\t\n");
+                }
+                //_labels.ForEach(label => sw.WriteLine(label + " (X)" + "\t" + label + " (Real)" + "\t" + " (Imag)" + "\t"));
             }
             // the following assumes that the data plotted is all doubles or all Complex 
             sw.WriteLine();

--- a/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
@@ -600,7 +600,22 @@ namespace Vts.Gui.Wpf.ViewModel
                         sw.WriteLine();
                         foreach (var t in _plotSeriesCollection)
                         {
-                            sw.Write(t[i].X + "\t" + t[i].Y + "\t");
+                            if (XAxisSpacingOptionVm.SelectedValue == ScalingType.Log)
+                            {
+                                sw.Write(Math.Pow(10, t[i].X) + "\t");
+                            }
+                            else
+                            {
+                                sw.Write(t[i].X + "\t");
+                            }
+                            if (YAxisSpacingOptionVm.SelectedValue == ScalingType.Log)
+                            {
+                                sw.Write(Math.Pow(10, t[i].Y) + "\t");
+                            }
+                            else
+                            {
+                                sw.Write(t[i].Y + "\t");
+                            }
                         }
                     }
                 }

--- a/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
@@ -13,8 +13,8 @@ using System.Windows;
 using System.Windows.Input;
 using Vts.Extensions;
 using Vts.Gui.Wpf.Extensions;
+using Vts.Gui.Wpf.FileSystem;
 using Vts.Gui.Wpf.Model;
-using static Vts.Gui.Wpf.ViewModel.PlotViewModel;
 using FontWeights = OxyPlot.FontWeights;
 
 namespace Vts.Gui.Wpf.ViewModel
@@ -192,49 +192,15 @@ namespace Vts.Gui.Wpf.ViewModel
             _saveFileDialog = saveFileDialog;
         }
 
-        public interface ISaveFileDialog
-        { 
-            string Filter { get; set; }
-            bool? ShowDialog();
-            string FileName { get; set; }
-        }
-
-        public class SaveFileDialog : ISaveFileDialog
-        {
-            public string Filter { get; set; }
-            public bool? ShowDialog()
-            {
-                var dialog = new Microsoft.Win32.SaveFileDialog
-                {
-                    DefaultExt = ".txt",
-                    Filter = Filter
-                };
-                var result = dialog.ShowDialog();
-                FileName = dialog.FileName;
-                return result;
-            }
-
-            public string FileName { get; set; }
-        }
-
-        public interface ITextFileService
-        {
-            public Tuple<FileStream, string> OpenTextFile();
-        }
-
         public Tuple<FileStream, string> OpenTextFile()
         {
             _saveFileDialog ??= new SaveFileDialog();
             _saveFileDialog.Filter = "Text |*.txt";
+            _saveFileDialog.DefaultExtension = ".txt";
 
             var accept = _saveFileDialog.ShowDialog();
 
             return accept.GetValueOrDefault(false) ? Tuple.Create(File.Open(_saveFileDialog.FileName, FileMode.Create), _saveFileDialog.FileName) : null;
-        }
-
-        public interface IFileSystem
-        {
-            string WriteExportedData(string path, Encoding encoding);
         }
 
         public RelayCommand<Array> PlotValues { get; set; }
@@ -653,25 +619,6 @@ namespace Vts.Gui.Wpf.ViewModel
             var file = OpenTextFile();
             if (file == null || file.Item2 == "") return;
             WriteExportedData(file, Encoding.UTF8);
-
-            //// Create SaveFileDialog 
-            //var dialog = new SaveFileDialog
-            //{
-            //    DefaultExt = ".txt",
-            //    Filter = "Text Files (*.txt)|*.txt"
-            //};
-
-            //// Display OpenFileDialog by calling ShowDialog method 
-            //var result = dialog.ShowDialog();
-
-            //// if the file dialog returns true - file was selected 
-            //var filename = "";
-            //if (result == true)
-            //{
-            //    // Get the filename from the dialog 
-            //    filename = dialog.FileName;
-            //}
-
         }
 
         protected virtual void WriteExportedData(Tuple<FileStream,string> file, Encoding encoding)

--- a/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
@@ -595,30 +595,30 @@ namespace Vts.Gui.Wpf.ViewModel
             sw.Write("%");
             if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
             {
-                _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Y)" + "\t"));
+                _labels.ForEach(label => sw.WriteLine(label + " (X)" + "\t" + " (Y)" + "\t"));
+                sw.WriteLine("%");
             }
             else // ComplexDataPoint
             {
-                _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Real)" + "\t" + label + " (Imag)" + "\t"));
+                _labels.ForEach(label => sw.WriteLine(label + " (X)" + "\t" + label + " (Real)" + "\t" + " (Imag)" + "\t"));
             }
+            // the following assumes that the data plotted is all doubles or all Complex 
             sw.WriteLine();
             foreach (var dataSet in DataSeriesCollection)
             {
-                sw.WriteLine();
-                if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
+                sw.WriteLine(); 
+                if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint) // doubles
                 {
                     foreach (var t in dataSet.DataPoints.Cast<DoubleDataPoint>().ToArray())
                     {
-                        sw.Write(t.X + "\t" + t.Y + "\t");
-                        sw.WriteLine();
+                        sw.WriteLine(t.X + "\t" + t.Y + "\t");
                     }
                 }
-                else  // ComplexDataPoint
-                {
+                else  // Complex
+                { 
                     foreach (var t in dataSet.DataPoints.Cast<ComplexDataPoint>().ToArray())
                     {
-                        sw.Write(t.X + "\t" + t.Y.Real + "\t" + t.Y.Imaginary + "\t");
-                        sw.WriteLine();
+                        sw.WriteLine(t.X + "\t" + t.Y.Real + "\t" + t.Y.Imaginary + "\t");
                     }
                 }
             }

--- a/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
@@ -593,14 +593,33 @@ namespace Vts.Gui.Wpf.ViewModel
                 using (var sw = new StreamWriter(stream))
                 {
                     sw.Write("%");
-                    _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Y)" + "\t"));
-                    sw.WriteLine();
-                    for (var i = 0; i < DataSeriesCollection.Count - 1; i++)
+                    if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
                     {
-                            sw.WriteLine();
-                        foreach (var t in _plotSeriesCollection)
+                        _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Y)" + "\t"));
+                    }
+                    else // ComplexDataPoint
+                    {
+                        _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Real)" + "\t" + label + " (Imag)" + "\t"));
+                    }
+                    sw.WriteLine();
+                    for (var i = 0; i < DataSeriesCollection.Count; i++)
+                    {
+                        sw.WriteLine();
+                        if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
                         {
-                            sw.Write(t[i].X + "\t" + t[i].Y + "\t");
+                            foreach (var t in DataSeriesCollection[i].DataPoints.Cast<DoubleDataPoint>().ToArray())
+                            {
+                                sw.Write(t.X + "\t" + t.Y + "\t");
+                                sw.WriteLine();
+                            }
+                        }
+                        else  // ComplexDataPoint
+                        {
+                            foreach (var t in DataSeriesCollection[i].DataPoints.Cast<ComplexDataPoint>().ToArray())
+                            {
+                                sw.Write(t.X + "\t" + t.Y.Real + "\t" + t.Y.Imaginary + "\t");
+                                sw.WriteLine();
+                            }
                         }
                     }
                 }

--- a/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/PlotViewModel.cs
@@ -569,58 +569,56 @@ namespace Vts.Gui.Wpf.ViewModel
         /// <param name="e"></param>
         private void Plot_ExportDataToText_Executed(object sender, ExecutedRoutedEventArgs e)
         {
-            if (_labels != null && _labels.Count > 0 && DataSeriesCollection != null && DataSeriesCollection.Count > 0)
+            if (_labels == null || _labels.Count <= 0 || DataSeriesCollection == null ||
+                DataSeriesCollection.Count <= 0) return;
+
+            // Create SaveFileDialog 
+            var dialog = new SaveFileDialog
             {
-                    // Create SaveFileDialog 
-                    var dialog = new SaveFileDialog
-                {
-                    DefaultExt = ".txt",
-                    Filter = "Text Files (*.txt)|*.txt"
-                };
+                DefaultExt = ".txt",
+                Filter = "Text Files (*.txt)|*.txt"
+            };
 
-                // Display OpenFileDialog by calling ShowDialog method 
-                var result = dialog.ShowDialog();
+            // Display OpenFileDialog by calling ShowDialog method 
+            var result = dialog.ShowDialog();
 
-                // if the file dialog returns true - file was selected 
-                var filename = "";
-                if (result == true)
+            // if the file dialog returns true - file was selected 
+            var filename = "";
+            if (result == true)
+            {
+                // Get the filename from the dialog 
+                filename = dialog.FileName;
+            }
+            if (filename == "") return;
+            var stream = new FileStream(filename, FileMode.Create);
+            using var sw = new StreamWriter(stream);
+            sw.Write("%");
+            if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
+            {
+                _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Y)" + "\t"));
+            }
+            else // ComplexDataPoint
+            {
+                _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Real)" + "\t" + label + " (Imag)" + "\t"));
+            }
+            sw.WriteLine();
+            foreach (var dataSet in DataSeriesCollection)
+            {
+                sw.WriteLine();
+                if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
                 {
-                    // Get the filename from the dialog 
-                    filename = dialog.FileName;
-                }
-                if (filename == "") return;
-                var stream = new FileStream(filename, FileMode.Create);
-                using (var sw = new StreamWriter(stream))
-                {
-                    sw.Write("%");
-                    if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
+                    foreach (var t in dataSet.DataPoints.Cast<DoubleDataPoint>().ToArray())
                     {
-                        _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Y)" + "\t"));
-                    }
-                    else // ComplexDataPoint
-                    {
-                        _labels.ForEach(label => sw.Write(label + " (X)" + "\t" + label + " (Real)" + "\t" + label + " (Imag)" + "\t"));
-                    }
-                    sw.WriteLine();
-                    for (var i = 0; i < DataSeriesCollection.Count; i++)
-                    {
+                        sw.Write(t.X + "\t" + t.Y + "\t");
                         sw.WriteLine();
-                        if (DataSeriesCollection[0].DataPoints[0] is DoubleDataPoint)
-                        {
-                            foreach (var t in DataSeriesCollection[i].DataPoints.Cast<DoubleDataPoint>().ToArray())
-                            {
-                                sw.Write(t.X + "\t" + t.Y + "\t");
-                                sw.WriteLine();
-                            }
-                        }
-                        else  // ComplexDataPoint
-                        {
-                            foreach (var t in DataSeriesCollection[i].DataPoints.Cast<ComplexDataPoint>().ToArray())
-                            {
-                                sw.Write(t.X + "\t" + t.Y.Real + "\t" + t.Y.Imaginary + "\t");
-                                sw.WriteLine();
-                            }
-                        }
+                    }
+                }
+                else  // ComplexDataPoint
+                {
+                    foreach (var t in dataSet.DataPoints.Cast<ComplexDataPoint>().ToArray())
+                    {
+                        sw.Write(t.X + "\t" + t.Y.Real + "\t" + t.Y.Imaginary + "\t");
+                        sw.WriteLine();
                     }
                 }
             }


### PR DESCRIPTION
To export non-log10 data when plot (X/Y) Axis Spacing is set to Log10, I check if either of these are set and if so, I undo the Log10 when exporting.  Actual data in _plotSeriesCollection is not modified.

I am creating a draft PR for now.