### PR TITLE
Bugfix/98 bug when using spectral panel inputs in the forward and inverse solver panels

### DIFF
--- a/Vts.Gui.Wpf.Test/View/Panels/PanelViewTests.cs
+++ b/Vts.Gui.Wpf.Test/View/Panels/PanelViewTests.cs
@@ -179,19 +179,17 @@ public class PanelViewTests : ViewTestBase
         viewModel.ExecuteForwardSolverCommand.Execute(null);
         // ExecuteForwardSolver default settings
         var plotViewModel = windowViewModel.PlotVm;
-        const double d1 = 0.01;
-        const int i1 = 1;
+        var mua = spectralInput ? 0.1676 : 0.01;
+        var musp = spectralInput ? 2.2123 : 1;
         const double g = 0.8;
         const double n = 1.4;
-        const double d2 = 0.01;
-        const double d3 = 1;
         const double diameter = 2;
         // Textbox output
         var s1 = StringLookup.GetLocalizedString("Label_ForwardSolver") +
                  StringLookup.GetLocalizedString("Label_MuA") + "=" +
-                 d1.ToString(CultureInfo.CurrentCulture) + " " +
+                 mua.ToString(CultureInfo.CurrentCulture) + " " +
                  StringLookup.GetLocalizedString("Label_MuSPrime") + "=" +
-                 i1.ToString(CultureInfo.CurrentCulture) + " g=" +
+                 musp.ToString(CultureInfo.CurrentCulture) + " g=" +
                  g.ToString(CultureInfo.CurrentCulture) + " n=" +
                  n.ToString(CultureInfo.CurrentCulture) + "; " +
                  StringLookup.GetLocalizedString("Label_Units") + " = mm⁻¹\r";
@@ -225,10 +223,10 @@ public class PanelViewTests : ViewTestBase
         else
         {
             s3 += StringLookup.GetLocalizedString("Label_MuA") + " = " +
-                  d2 + " " +
+                  mua + " " +
                   StringLookup.GetLocalizedString("Measurement_Inv_mm") + "\r" +
                   StringLookup.GetLocalizedString("Label_MuSPrime") + " = " +
-                  d3 + " " +
+                  musp + " " +
                   StringLookup.GetLocalizedString("Measurement_Inv_mm") + "\r";
         }
         s3 += StringLookup.GetLocalizedString("Label_Diameter") + " = " +

--- a/Vts.Gui.Wpf.Test/ViewModel/Panels/SubPanels/ConstantAxisViewModelTests.cs
+++ b/Vts.Gui.Wpf.Test/ViewModel/Panels/SubPanels/ConstantAxisViewModelTests.cs
@@ -27,16 +27,18 @@ internal class ConstantAxisViewModelTests
     [Test]
     public void Verify_Constant_axis_wavelength()
     {
-        Assert.Throws<InvalidOperationException>(() =>
+        var constantAxisViewModel = new ConstantAxisViewModel
         {
-            _ = new ConstantAxisViewModel
-            {
-                AxisLabel = "Wavelength",
-                AxisType = IndependentVariableAxis.Wavelength,
-                AxisUnits = "nm",
-                AxisValue = 700,
-                ImageHeight = 2
-            };
-        });
+            AxisLabel = "Wavelength",
+            AxisType = IndependentVariableAxis.Wavelength,
+            AxisUnits = "nm",
+            AxisValue = 700,
+            ImageHeight = 2
+        };
+        Assert.That(constantAxisViewModel.AxisLabel, Is.EqualTo("Wavelength"));
+        Assert.That(constantAxisViewModel.AxisType, Is.EqualTo(IndependentVariableAxis.Wavelength));
+        Assert.That(constantAxisViewModel.AxisUnits, Is.EqualTo("nm"));
+        Assert.That(constantAxisViewModel.AxisValue, Is.EqualTo(700));
+        Assert.That(constantAxisViewModel.ImageHeight, Is.EqualTo(2));
     }
 }

--- a/Vts.Gui.Wpf/Helpers/Calculations.cs
+++ b/Vts.Gui.Wpf/Helpers/Calculations.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Vts.Gui.Wpf.Helpers;
+
+internal static class Calculations
+{
+
+    /// <summary>
+    /// Compares two doubles using a small tolerance to avoid exact equality checks.
+    /// </summary>
+    internal static bool AreApproximatelyEqual(double a, double b, double tolerance = 1e-9)
+    {
+        return Math.Abs(a - b) <= tolerance;
+    }
+
+}

--- a/Vts.Gui.Wpf/Helpers/Calculations.cs
+++ b/Vts.Gui.Wpf/Helpers/Calculations.cs
@@ -4,7 +4,6 @@ namespace Vts.Gui.Wpf.Helpers;
 
 internal static class Calculations
 {
-
     /// <summary>
     /// Compares two doubles using a small tolerance to avoid exact equality checks.
     /// </summary>
@@ -12,5 +11,4 @@ internal static class Calculations
     {
         return Math.Abs(a - b) <= tolerance;
     }
-
 }

--- a/Vts.Gui.Wpf/ViewModel/Panels/Base/BaseSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/Base/BaseSolverViewModel.cs
@@ -89,7 +89,7 @@ public abstract class BaseSolverViewModel : BindableObject
         switch (args.PropertyName)
         {
             case "ConstantAxesVMs":
-                if (useSpectralPanelDataAndNotNull &&
+                if (useSpectralPanelDataAndNotNull && WindowViewModel.Current != null &&
                     SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
                         axis => axis.AxisType == IndependentVariableAxis.Wavelength))
                 {

--- a/Vts.Gui.Wpf/ViewModel/Panels/Base/BaseSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/Base/BaseSolverViewModel.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using Vts.Gui.Wpf.Helpers;
+using Vts.Gui.Wpf.ViewModel.Controls;
+using Vts.Gui.Wpf.ViewModel.Panels.SubPanels;
+
+namespace Vts.Gui.Wpf.ViewModel.Panels;
+
+/// <summary>
+/// Base view model for solvers that provides common properties and logic for handling solution domain options,
+/// including the use of spectral panel data and the display of optical properties.
+/// </summary>
+public abstract class BaseSolverViewModel : BindableObject
+{
+    private RangeViewModel[] _allRangeVMs;
+
+    public RangeViewModel[] AllRangeVMs
+    {
+        get => _allRangeVMs;
+        set
+        {
+            _allRangeVMs = value;
+            OnPropertyChanged(nameof(AllRangeVMs));
+        }
+    }
+
+    public bool ShowOpticalProperties
+    {
+        get;
+        set
+        {
+            field = value;
+            OnPropertyChanged(nameof(ShowOpticalProperties));
+        }
+    }
+
+    public bool UseSpectralPanelData
+    {
+        get;
+        set
+        {
+            field = value;
+            OnPropertyChanged(nameof(UseSpectralPanelData));
+        }
+    }
+
+    public SolutionDomainOptionViewModel SolutionDomainTypeOptionVm
+    {
+        get;
+        set
+        {
+            field = value;
+            OnPropertyChanged(nameof(SolutionDomainTypeOptionVm));
+        }
+    }
+
+    /// <summary>
+    /// Handles the <see cref="BindableObject.PropertyChanged"/> event for an optical property view model.
+    /// Updates the <see cref="UseSpectralPanelData"/> property based on the current state of 
+    /// <see cref="SolutionDomainTypeOptionVm"/> and updates the wavelength with the value from
+    /// the spectral panel if spectral panel data is being used.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="args">The property that changed.</param>
+    /// <remarks>The optical properties will be updated by the spectral panel if the
+    /// "use spectral panel inputs" checkbox is checked.</remarks>
+    protected void OpticalPropertyVm_PropertyChanged(object sender, PropertyChangedEventArgs args)
+    {
+        if (UseSpectralPanelData && WindowViewModel.Current != null &&
+            WindowViewModel.Current.SpectralMappingVm != null)
+        {
+            UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
+        }
+    }
+
+    /// <summary>
+    /// Handles the <see cref="BindableObject.PropertyChanged"/> event for the <c>SolutionDomainTypeOptionVm</c>.
+    /// Updates dependent properties or performs actions based on the property that changed.
+    /// </summary>
+    /// <param name="sender">The source of the event, typically the <c>SolutionDomainTypeOptionVm</c>.</param>
+    /// <param name="args">The property that changed.</param>
+    protected void SolutionDomainTypeOptionVm_PropertyChanged(object sender, PropertyChangedEventArgs args)
+    {
+        var useSpectralPanelDataAndNotNull = SolutionDomainTypeOptionVm.UseSpectralInputs &&
+                                             WindowViewModel.Current != null &&
+                                             WindowViewModel.Current.SpectralMappingVm != null;
+
+        switch (args.PropertyName)
+        {
+            case "ConstantAxesVMs":
+                if (useSpectralPanelDataAndNotNull &&
+                    SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
+                        axis => axis.AxisType == IndependentVariableAxis.Wavelength))
+                {
+                    WindowViewModel.Current.SpectralMappingVm.Wavelength = SolutionDomainTypeOptionVm.ConstantAxesVMs
+                        .First(axis => axis.AxisType == IndependentVariableAxis.Wavelength).AxisValue;
+                }
+                break;
+            case "UseSpectralInputs":
+                UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
+                break;
+            case "IndependentAxesVMs":
+                {
+                    AllRangeVMs =
+                        (from i in
+                                Enumerable.Range(0,
+                                    SolutionDomainTypeOptionVm.IndependentVariableAxisOptionVm.SelectedValues.Length)
+                         orderby i descending
+                         select
+                         useSpectralPanelDataAndNotNull &&
+                         SolutionDomainTypeOptionVm.IndependentVariableAxisOptionVm.SelectedValues[i] ==
+                         IndependentVariableAxis.Wavelength
+                             ? WindowViewModel.Current.SpectralMappingVm.WavelengthRangeVm
+                             : SolutionDomainTypeOptionVm.IndependentAxesVMs[i].AxisRangeVm).ToArray();
+
+                    ShowOpticalProperties = _allRangeVMs.All(value => value.AxisType != IndependentVariableAxis.Wavelength);
+
+                    if (useSpectralPanelDataAndNotNull &&
+                        SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
+                            axis => axis.AxisType == IndependentVariableAxis.Wavelength) &&
+                        WindowViewModel.Current != null &&
+                        WindowViewModel.Current.SpectralMappingVm != null)
+                    {
+                        UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
+                    }
+                    break;
+                }
+        }
+    }
+
+    /// <summary>
+    /// Updates the solution domain's wavelength axis value if it differs from the specified wavelength.
+    /// </summary>
+    /// <remarks>If the solution domain does not contain a wavelength axis, or if the current value is already
+    /// approximately equal to the specified wavelength, no update is performed.</remarks>
+    /// <param name="wv">The wavelength value to set for the solution domain's wavelength axis.</param>
+    protected void UpdateSolutionDomainWithWavelength(double wv)
+    {
+        var wvAxis = SolutionDomainTypeOptionVm.ConstantAxesVMs.FirstOrDefault(axis => axis.AxisType == IndependentVariableAxis.Wavelength);
+        if (wvAxis != null && !Calculations.AreApproximatelyEqual(wvAxis.AxisValue, wv))
+        {
+            wvAxis.AxisValue = wv;
+        }
+    }
+
+    /// <summary>
+    /// Function to provide ordering information for assembling forward calls
+    /// </summary>
+    /// <param name="axis">The independent variable axis for which to determine the order.</param>
+    /// <returns>The order value for the specified axis.</returns>
+    protected static int GetParameterOrder(IndependentVariableAxis axis)
+    {
+        return axis switch
+        {
+            IndependentVariableAxis.Wavelength => 0,
+            IndependentVariableAxis.Rho => 1,
+            IndependentVariableAxis.Fx => 1,
+            IndependentVariableAxis.Time => 2,
+            IndependentVariableAxis.Ft => 2,
+            IndependentVariableAxis.Z => 3,
+            _ => throw new ArgumentOutOfRangeException(nameof(axis))
+        };
+    }
+}

--- a/Vts.Gui.Wpf/ViewModel/Panels/ForwardSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/ForwardSolverViewModel.cs
@@ -450,8 +450,8 @@ public class ForwardSolverViewModel : BindableObject
                        StringLookup.GetLocalizedString("Measurement_Inv_mm");
         }
 
-        if (_allRangeVMs.Length <= 1) return [modelString + opString + gaussianDiameter];
         var isWavelengthPlot = _allRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
+        if (_allRangeVMs.Length <= 1) return [modelString + (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString) + gaussianDiameter];
         var secondaryRangeVm = isWavelengthPlot
             ? _allRangeVMs.First(vm => vm.AxisType != IndependentVariableAxis.Wavelength)
             : _allRangeVMs

--- a/Vts.Gui.Wpf/ViewModel/Panels/ForwardSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/ForwardSolverViewModel.cs
@@ -7,6 +7,7 @@ using Vts.Common;
 using Vts.Extensions;
 using Vts.Factories;
 using Vts.Gui.Wpf.Extensions;
+using Vts.Gui.Wpf.Helpers;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.ViewModel.Controls;
 using Vts.Gui.Wpf.ViewModel.Helpers;
@@ -70,19 +71,30 @@ public class ForwardSolverViewModel : BindableObject
 
         SolutionDomainTypeOptionVm.PropertyChanged += (_, args) =>
         {
+            var useSpectralPanelDataAndNotNull = SolutionDomainTypeOptionVm.UseSpectralInputs &&
+                                                 WindowViewModel.Current != null &&
+                                                 WindowViewModel.Current.SpectralMappingVm != null;
             switch (args.PropertyName)
             {
+                case "ConstantAxesVMs":
+                    // update solution domain wavelength constant if applicable
+                    if (useSpectralPanelDataAndNotNull &&
+                        WindowViewModel.Current != null &&
+                        SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
+                            axis => axis.AxisType == IndependentVariableAxis.Wavelength))
+                    {
+                        
+                        WindowViewModel.Current.SpectralMappingVm.Wavelength = SolutionDomainTypeOptionVm.ConstantAxesVMs
+                            .First(axis => axis.AxisType == IndependentVariableAxis.Wavelength).AxisValue;
+                    }
+                    break;
                 case "UseSpectralInputs":
                     UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
                     break;
                 case "IndependentAxesVMs":
                 {
-                    var useSpectralPanelDataAndNotNull = SolutionDomainTypeOptionVm.UseSpectralInputs &&
-                                                         WindowViewModel.Current != null &&
-                                                         WindowViewModel.Current.SpectralMappingVm != null;
-
                     AllRangeVMs =
-                        [.. (from i in
+                        [.. from i in
                                 Enumerable.Range(0,
                                     SolutionDomainTypeOptionVm.IndependentVariableAxisOptionVm.SelectedValues.Length)
                             orderby i descending
@@ -93,7 +105,7 @@ public class ForwardSolverViewModel : BindableObject
                                 IndependentVariableAxis.Wavelength
                                     ? WindowViewModel.Current.SpectralMappingVm.WavelengthRangeVm
                                     // bind to same instance, not a copy
-                                    : SolutionDomainTypeOptionVm.IndependentAxesVMs[i].AxisRangeVm)];
+                                    : SolutionDomainTypeOptionVm.IndependentAxesVMs[i].AxisRangeVm];
 
                     // if the independent axis is wavelength, then hide optical properties (because they come from spectral panel)
                     ShowOpticalProperties =
@@ -128,57 +140,15 @@ public class ForwardSolverViewModel : BindableObject
                 UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
             }
         };
+    }
 
-        if (WindowViewModel.Current.SpectralMappingVm != null)
+    private void UpdateSolutionDomainWithWavelength(double wv)
+    {
+        var wvAxis = SolutionDomainTypeOptionVm.ConstantAxesVMs.FirstOrDefault(axis => axis.AxisType == IndependentVariableAxis.Wavelength);
+        // Use a tolerance for floating point comparisons to avoid exact inequality checks
+        if (wvAxis != null && !Calculations.AreApproximatelyEqual(wvAxis.AxisValue, wv))
         {
-            WindowViewModel.Current.SpectralMappingVm.PropertyChanged += (_, args) =>
-            {
-                if (args.PropertyName == "Wavelength")
-                {
-                    //need to get the value from the checkbox in case UseSpectralPanelData has not yet been updated
-                    if (SolutionDomainTypeOptionVm != null)
-                    {
-                        UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
-                    }
-                    if (UseSpectralPanelData && WindowViewModel.Current != null &&
-                        WindowViewModel.Current.SpectralMappingVm != null)
-                    {
-                        UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
-                    }
-                }
-
-                if (args.PropertyName == "OpticalProperties")
-                {
-                    //need to get the value from the checkbox in case UseSpectralPanelData has not yet been updated
-                    if (SolutionDomainTypeOptionVm != null)
-                    {
-                        UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
-                    }
-                    if (UseSpectralPanelData && WindowViewModel.Current != null &&
-                        WindowViewModel.Current.SpectralMappingVm != null)
-                    {
-                        if (IsMultiRegion && MultiRegionTissueVm != null)
-                        {
-                            MultiRegionTissueVm.RegionsVm.ForEach(region =>
-                                ((dynamic) region).OpticalPropertyVm.SetOpticalProperties(
-                                    WindowViewModel.Current.SpectralMappingVm.OpticalProperties));
-                        }
-                        else if (OpticalPropertyVm != null)
-                        {
-                            OpticalPropertyVm.SetOpticalProperties(
-                                WindowViewModel.Current.SpectralMappingVm.OpticalProperties);
-                        }
-                    }
-                }
-            };
-        }
-
-        return;
-
-        void UpdateSolutionDomainWithWavelength(double wv)
-        {
-            var wvAxis = SolutionDomainTypeOptionVm.ConstantAxesVMs.FirstOrDefault(axis => axis.AxisType == IndependentVariableAxis.Wavelength);
-            wvAxis?.AxisValue = wv;
+            wvAxis.AxisValue = wv;
         }
     }
 
@@ -317,7 +287,8 @@ public class ForwardSolverViewModel : BindableObject
         var sd = SolutionDomainTypeOptionVm;
         var axesLabels = new PlotAxesLabels(
             sd.SelectedDisplayName, sd.SelectedValue.GetUnits(),
-            sd.IndependentAxesVMs.First(vm => vm.AxisType == AllRangeVMs[0].AxisType),
+            sd.IndependentAxesVMs.First(vm =>
+                vm.AxisType == AllRangeVMs[0].AxisType),
             sd.ConstantAxesVMs)
         {
             IsComplexPlot = ComputationFactory.IsComplexSolver(SolutionDomainTypeOptionVm.SelectedValue)

--- a/Vts.Gui.Wpf/ViewModel/Panels/ForwardSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/ForwardSolverViewModel.cs
@@ -1,13 +1,12 @@
-﻿using System;
+﻿using CommunityToolkit.Mvvm.Input;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using CommunityToolkit.Mvvm.Input;
 using Vts.Common;
 using Vts.Extensions;
 using Vts.Factories;
 using Vts.Gui.Wpf.Extensions;
-using Vts.Gui.Wpf.Helpers;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.ViewModel.Controls;
 using Vts.Gui.Wpf.ViewModel.Helpers;
@@ -24,30 +23,22 @@ namespace Vts.Gui.Wpf.ViewModel.Panels;
 /// <summary>
 ///     View model implementing Forward Solver panel functionality
 /// </summary>
-public class ForwardSolverViewModel : BindableObject
+public class ForwardSolverViewModel : BaseSolverViewModel
 {
-    private RangeViewModel[] _allRangeVMs;
-
     // private fields to cache created instances of tissue inputs, created on-demand in GetTissueInputVm (vs up-front in constructor)
     private OpticalProperties _currentHomogeneousOpticalProperties;
     private MultiLayerTissueInput _currentMultiLayerTissueInput;
     private SemiInfiniteTissueInput _currentSemiInfiniteTissueInput;
     private SingleEllipsoidTissueInput _currentSingleEllipsoidTissueInput;
 
-    private bool _showOpticalProperties;
-
     private object _tissueInputVm;
     // either an OpticalPropertyViewModel or a MultiRegionTissueViewModel is stored here, and dynamically displayed
 
-    private bool _useSpectralPanelData;
-
     public ForwardSolverViewModel()
     {
-        _showOpticalProperties = true;
-        _useSpectralPanelData = false;
-
-
-        _allRangeVMs = [new RangeViewModel {Title = StringLookup.GetLocalizedString("IndependentVariableAxis_Rho")}];
+        ShowOpticalProperties = true;
+        UseSpectralPanelData = false;
+        AllRangeVMs = [new RangeViewModel { Title = StringLookup.GetLocalizedString("IndependentVariableAxis_Rho") }];
 
 #if WHITELIST 
         ForwardSolverTypeOptionVm = new OptionViewModel<ForwardSolverType>("Forward Model",false, WhiteList.ForwardSolverTypes);
@@ -55,6 +46,7 @@ public class ForwardSolverViewModel : BindableObject
         ForwardSolverTypeOptionVm = new OptionViewModel<ForwardSolverType>("Forward Model", false);
 #endif
         SolutionDomainTypeOptionVm = new SolutionDomainOptionViewModel("Solution Domain", SolutionDomainType.ROfRho);
+        SolutionDomainTypeOptionVm.PropertyChanged += SolutionDomainTypeOptionVm_PropertyChanged;
 
         ForwardAnalysisTypeOptionVm = new OptionViewModel<ForwardAnalysisType>(StringLookup.GetLocalizedString("Heading_ModelAnalysisOutput"), true);
 
@@ -67,89 +59,12 @@ public class ForwardSolverViewModel : BindableObject
             TissueInputVm = GetTissueInputVm(IsMultiRegion ? "MultiLayer" : "SemiInfinite");
             UpdateAvailableOptions();
         };
+
         ForwardSolverTypeOptionVm.SelectedValue = ForwardSolverType.PointSourceSDA; // force the model choice here?
-
-        SolutionDomainTypeOptionVm.PropertyChanged += (_, args) =>
-        {
-            var useSpectralPanelDataAndNotNull = SolutionDomainTypeOptionVm.UseSpectralInputs &&
-                                                 WindowViewModel.Current != null &&
-                                                 WindowViewModel.Current.SpectralMappingVm != null;
-            switch (args.PropertyName)
-            {
-                case "ConstantAxesVMs":
-                    // update solution domain wavelength constant if applicable
-                    if (useSpectralPanelDataAndNotNull &&
-                        WindowViewModel.Current != null &&
-                        SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
-                            axis => axis.AxisType == IndependentVariableAxis.Wavelength))
-                    {
-                        
-                        WindowViewModel.Current.SpectralMappingVm.Wavelength = SolutionDomainTypeOptionVm.ConstantAxesVMs
-                            .First(axis => axis.AxisType == IndependentVariableAxis.Wavelength).AxisValue;
-                    }
-                    break;
-                case "UseSpectralInputs":
-                    UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
-                    break;
-                case "IndependentAxesVMs":
-                {
-                    AllRangeVMs =
-                        [.. from i in
-                                Enumerable.Range(0,
-                                    SolutionDomainTypeOptionVm.IndependentVariableAxisOptionVm.SelectedValues.Length)
-                            orderby i descending
-                            // descending so that wavelength takes highest priority, then time/time frequency, then space/spatial frequency
-                            select
-                                useSpectralPanelDataAndNotNull &&
-                                SolutionDomainTypeOptionVm.IndependentVariableAxisOptionVm.SelectedValues[i] ==
-                                IndependentVariableAxis.Wavelength
-                                    ? WindowViewModel.Current.SpectralMappingVm.WavelengthRangeVm
-                                    // bind to same instance, not a copy
-                                    : SolutionDomainTypeOptionVm.IndependentAxesVMs[i].AxisRangeVm];
-
-                    // if the independent axis is wavelength, then hide optical properties (because they come from spectral panel)
-                    ShowOpticalProperties =
-                        _allRangeVMs.All(value => value.AxisType != IndependentVariableAxis.Wavelength);
-
-                    // update solution domain wavelength constant if applicable
-                    if (useSpectralPanelDataAndNotNull &&
-                        WindowViewModel.Current != null &&
-                        SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
-                            axis => axis.AxisType == IndependentVariableAxis.Wavelength))
-                    {
-                        UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
-                    }
-
-                    break;
-                }
-            }
-        };
 
         ExecuteForwardSolverCommand = new RelayCommand(ExecuteForwardSolver_Executed);
 
-        OpticalPropertyVm.PropertyChanged += (_, _) =>
-        {
-            //need to get the value from the checkbox in case UseSpectralPanelData has not yet been updated
-            if (SolutionDomainTypeOptionVm != null)
-            {
-                UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
-            }
-            if (UseSpectralPanelData && WindowViewModel.Current != null &&
-                WindowViewModel.Current.SpectralMappingVm != null)
-            {
-                UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
-            }
-        };
-    }
-
-    private void UpdateSolutionDomainWithWavelength(double wv)
-    {
-        var wvAxis = SolutionDomainTypeOptionVm.ConstantAxesVMs.FirstOrDefault(axis => axis.AxisType == IndependentVariableAxis.Wavelength);
-        // Use a tolerance for floating point comparisons to avoid exact inequality checks
-        if (wvAxis != null && !Calculations.AreApproximatelyEqual(wvAxis.AxisValue, wv))
-        {
-            wvAxis.AxisValue = wv;
-        }
+        OpticalPropertyVm.PropertyChanged += OpticalPropertyVm_PropertyChanged;
     }
 
     public RelayCommand ExecuteForwardSolverCommand { get; set; }
@@ -159,39 +74,9 @@ public class ForwardSolverViewModel : BindableObject
 
     public bool IsGaussianForwardModel => ForwardSolverTypeOptionVm.SelectedValue.IsGaussianForwardModel();
 
-    public bool ShowOpticalProperties
-    {
-        get => _showOpticalProperties;
-        set
-        {
-            _showOpticalProperties = value;
-            OnPropertyChanged(nameof(ShowOpticalProperties));
-        }
-    }
-
     public bool IsMultiRegion => ForwardSolverTypeOptionVm.SelectedValue.IsMultiRegionForwardModel();
 
     public bool IsSemiInfinite => !ForwardSolverTypeOptionVm.SelectedValue.IsMultiRegionForwardModel();
-
-    public bool UseSpectralPanelData
-    {
-        get => _useSpectralPanelData;
-        set
-        {
-            _useSpectralPanelData = value;
-            OnPropertyChanged(nameof(UseSpectralPanelData));
-        }
-    }
-
-    public SolutionDomainOptionViewModel SolutionDomainTypeOptionVm
-    {
-        get;
-        set
-        {
-            field = value;
-            OnPropertyChanged(nameof(SolutionDomainTypeOptionVm));
-        }
-    }
 
     public OptionViewModel<ForwardSolverType> ForwardSolverTypeOptionVm
     {
@@ -200,16 +85,6 @@ public class ForwardSolverViewModel : BindableObject
         {
             field = value;
             OnPropertyChanged(nameof(ForwardSolverTypeOptionVm));
-        }
-    }
-
-    public RangeViewModel[] AllRangeVMs
-    {
-        get => _allRangeVMs;
-        set
-        {
-            _allRangeVMs = value;
-            OnPropertyChanged(nameof(AllRangeVMs));
         }
     }
 
@@ -338,10 +213,6 @@ public class ForwardSolverViewModel : BindableObject
                 SolutionDomainTypeOptionVm.IsROfFxAndTimeEnabled = true;
                 SolutionDomainTypeOptionVm.IsROfFxAndFtEnabled = true;
             }
-            //SolutionDomainTypeOptionVm.EnableMultiAxis =
-            //    ForwardSolverTypeOptionVm.SelectedValue != ForwardSolverType.TwoLayerSDA;
-            //SolutionDomainTypeOptionVm.EnableSpectralPanelInputs = 
-            //    ForwardSolverTypeOptionVm.SelectedValue != ForwardSolverType.TwoLayerSDA;
         }
 
         if (ForwardAnalysisTypeOptionVm != null)
@@ -360,6 +231,7 @@ public class ForwardSolverViewModel : BindableObject
                 ForwardSolverTypeOptionVm.SelectedValue != ForwardSolverType.TwoLayerSDA;
         } 
     }
+    
     private object GetTissueInputVm(string tissueType)
     {
         // ops to use as the basis for instantiating multi-region tissues based on homogeneous values (for differential comparison)
@@ -396,7 +268,6 @@ public class ForwardSolverViewModel : BindableObject
         }
     }
 
-    // todo: rename? this was to get a concise name for the legend
     private string[] GetLegendLabels()
     {
         string modelString = null;
@@ -450,11 +321,11 @@ public class ForwardSolverViewModel : BindableObject
                        StringLookup.GetLocalizedString("Measurement_Inv_mm");
         }
 
-        var isWavelengthPlot = _allRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
-        if (_allRangeVMs.Length <= 1) return [modelString + (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString) + gaussianDiameter];
+        var isWavelengthPlot = AllRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
+        if (AllRangeVMs.Length <= 1) return [modelString + (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString) + gaussianDiameter];
         var secondaryRangeVm = isWavelengthPlot
-            ? _allRangeVMs.First(vm => vm.AxisType != IndependentVariableAxis.Wavelength)
-            : _allRangeVMs
+            ? AllRangeVMs.First(vm => vm.AxisType != IndependentVariableAxis.Wavelength)
+            : AllRangeVMs   
                 .First(vm => vm.AxisType != IndependentVariableAxis.Time && vm.AxisType != IndependentVariableAxis.Ft);
 
         var secondaryAxesStrings =
@@ -469,7 +340,6 @@ public class ForwardSolverViewModel : BindableObject
         return
             [.. secondaryAxesStrings.Select(
                 sas => modelString + sas + (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString) + gaussianDiameter)];
-
     }
 
     public IDataPoint[][] ExecuteForwardSolver()
@@ -489,11 +359,11 @@ public class ForwardSolverViewModel : BindableObject
 
     private IDataPoint[][] GetDataPoints(double[] reflectance)
     {
-        var plotIsVsWavelength = _allRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
+        var plotIsVsWavelength = AllRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
         var isComplexPlot = ComputationFactory.IsComplexSolver(SolutionDomainTypeOptionVm.SelectedValue);
         var forwardAnalysisType = ForwardAnalysisTypeOptionVm.SelectedValue;
         var isDerivativePlot = ForwardAnalysisTypeOptionVm.SelectedValue != ForwardAnalysisType.R;
-        var primaryIndependentValues = _allRangeVMs[0].Values.ToArray();
+        var primaryIndependentValues = AllRangeVMs[0].Values.ToArray();
         var numPointsPerCurve = primaryIndependentValues.Length;
 
         int numForwardValues;
@@ -534,25 +404,6 @@ public class ForwardSolverViewModel : BindableObject
 
             return new ComplexDataPoint(primaryIndependentValues[i], new Complex(reflectance[index], reflectance[index + numForwardValues]));
         }
-    }
-
-    /// <summary>
-    ///     Function to provide ordering information for assembling forward calls
-    /// </summary>
-    /// <param name="axis"></param>
-    /// <returns></returns>
-    private static int GetParameterOrder(IndependentVariableAxis axis)
-    {
-        return axis switch
-        {
-            IndependentVariableAxis.Wavelength => 0,
-            IndependentVariableAxis.Rho => 1,
-            IndependentVariableAxis.Fx => 1,
-            IndependentVariableAxis.Time => 2,
-            IndependentVariableAxis.Ft => 2,
-            IndependentVariableAxis.Z => 3,
-            _ => throw new ArgumentOutOfRangeException(nameof(axis))
-        };
     }
 
     private double[] GetParameterValues(IndependentVariableAxis axis)

--- a/Vts.Gui.Wpf/ViewModel/Panels/InverseSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/InverseSolverViewModel.cs
@@ -360,8 +360,8 @@ public class InverseSolverViewModel : BindableObject
                 break;
         }
 
-        if (_allRangeVMs.Length <= 1) return [solverString + modelString + opString];
         var isWavelengthPlot = _allRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
+        if (_allRangeVMs.Length <= 1) return [solverString + modelString + (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString)];
         var secondaryRangeVm = isWavelengthPlot
             ? _allRangeVMs.First(vm => vm.AxisType != IndependentVariableAxis.Wavelength)
             : _allRangeVMs.First(

--- a/Vts.Gui.Wpf/ViewModel/Panels/InverseSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/InverseSolverViewModel.cs
@@ -39,6 +39,7 @@ public class InverseSolverViewModel : BindableObject
 
         SolutionDomainTypeOptionVm = new SolutionDomainOptionViewModel("Solution Domain", SolutionDomainType.ROfRho)
             {
+                EnableSpectralPanelInputs = false,
                 EnableMultiAxis = false,
                 AllowMultiAxis = false
             };

--- a/Vts.Gui.Wpf/ViewModel/Panels/InverseSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/InverseSolverViewModel.cs
@@ -7,7 +7,6 @@ using System.Text;
 using Vts.Extensions;
 using Vts.Factories;
 using Vts.Gui.Wpf.Extensions;
-using Vts.Gui.Wpf.Helpers;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.Resources;
 using Vts.Gui.Wpf.ViewModel.Controls;
@@ -23,19 +22,14 @@ namespace Vts.Gui.Wpf.ViewModel.Panels;
 /// <summary>
 ///     View model implementing Inverse Solver panel functionality
 /// </summary>
-public class InverseSolverViewModel : BindableObject
+public class InverseSolverViewModel : BaseSolverViewModel
 {
-    private RangeViewModel[] _allRangeVMs;
-
-    private bool _showOpticalProperties;
-    private bool _useSpectralPanelData;
-
     public InverseSolverViewModel()
     {
-        _showOpticalProperties = true;
-        _useSpectralPanelData = false;
+        ShowOpticalProperties = true;
+        UseSpectralPanelData = false;
 
-        _allRangeVMs = [new RangeViewModel {Title = Strings.IndependentVariableAxis_Rho}];
+        AllRangeVMs = [new RangeViewModel {Title = Strings.IndependentVariableAxis_Rho}];
 
         SolutionDomainTypeOptionVm = new SolutionDomainOptionViewModel("Solution Domain", SolutionDomainType.ROfRho)
             {
@@ -44,61 +38,7 @@ public class InverseSolverViewModel : BindableObject
                 AllowMultiAxis = false
             };
 
-        SolutionDomainTypeOptionVm.PropertyChanged += (_, args) =>
-        {
-            var useSpectralPanelDataAndNotNull = SolutionDomainTypeOptionVm.UseSpectralInputs &&
-                                                 WindowViewModel.Current != null &&
-                                                 WindowViewModel.Current.SpectralMappingVm != null;
-
-            switch (args.PropertyName)
-            {
-                case "ConstantAxesVMs":
-                    // update solution domain wavelength constant if applicable
-                    if (useSpectralPanelDataAndNotNull &&
-                        WindowViewModel.Current != null &&
-                        SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
-                            axis => axis.AxisType == IndependentVariableAxis.Wavelength))
-                    {
-
-                        WindowViewModel.Current.SpectralMappingVm.Wavelength = SolutionDomainTypeOptionVm.ConstantAxesVMs
-                            .First(axis => axis.AxisType == IndependentVariableAxis.Wavelength).AxisValue;
-                    }
-                    break;
-                case "UseSpectralInputs":
-                    UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
-                    break;
-                case "IndependentAxesVMs":
-                {
-                    AllRangeVMs =
-                        (from i in
-                                Enumerable.Range(0,
-                                    SolutionDomainTypeOptionVm.IndependentVariableAxisOptionVm.SelectedValues.Length)
-                            orderby i descending
-                            // descending so that wavelength takes highest priority, then time/time frequency, then space/spatial frequency
-                            select
-                                useSpectralPanelDataAndNotNull &&
-                                SolutionDomainTypeOptionVm.IndependentVariableAxisOptionVm.SelectedValues[i] ==
-                                IndependentVariableAxis.Wavelength
-                                    ? WindowViewModel.Current.SpectralMappingVm.WavelengthRangeVm
-                                    // bind to same instance, not a copy
-                                    : SolutionDomainTypeOptionVm.IndependentAxesVMs[i].AxisRangeVm).ToArray();
-
-                    // if the independent axis is wavelength, then hide optical properties (because they come from spectral panel)
-                    ShowOpticalProperties = _allRangeVMs.All(value => value.AxisType != IndependentVariableAxis.Wavelength);
-
-                        // update solution domain wavelength constant if applicable
-                        if (useSpectralPanelDataAndNotNull &&
-                            SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
-                                axis => axis.AxisType == IndependentVariableAxis.Wavelength) && 
-                            WindowViewModel.Current != null && 
-                            WindowViewModel.Current.SpectralMappingVm != null)
-                        {
-                            UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
-                        }
-                        break;
-                }
-            }
-        };
+        SolutionDomainTypeOptionVm.PropertyChanged += SolutionDomainTypeOptionVm_PropertyChanged;
 
 #if WHITELIST
         MeasuredForwardSolverTypeOptionVm = new OptionViewModel<ForwardSolverType>(
@@ -130,52 +70,12 @@ public class InverseSolverViewModel : BindableObject
         CalculateInitialGuessCommand = new RelayCommand(CalculateInitialGuessCommand_Executed);
         SolveInverseCommand = new RelayCommand(SolveInverseCommand_Executed);
 
-        MeasuredOpticalPropertyVm.PropertyChanged += (_, _) =>
-        {
-            //need to get the value from the checkbox in case UseSpectralPanelData has not yet been updated
-            if (SolutionDomainTypeOptionVm != null)
-            {
-                UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
-            }
-            if (UseSpectralPanelData && WindowViewModel.Current != null &&
-                WindowViewModel.Current.SpectralMappingVm != null)
-            {
-                UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
-            }
-        };
-    }
-    private void UpdateSolutionDomainWithWavelength(double wv)
-    {
-        var wvAxis = SolutionDomainTypeOptionVm.ConstantAxesVMs.FirstOrDefault(axis => axis.AxisType == IndependentVariableAxis.Wavelength);
-        if (wvAxis != null && !Calculations.AreApproximatelyEqual(wvAxis.AxisValue, wv))
-        {
-            wvAxis.AxisValue = wv;
-        }
+        MeasuredOpticalPropertyVm.PropertyChanged += OpticalPropertyVm_PropertyChanged;
     }
 
     public RelayCommand SimulateMeasuredDataCommand { get; set; }
     public RelayCommand CalculateInitialGuessCommand { get; set; }
     public RelayCommand SolveInverseCommand { get; set; }
-
-    public SolutionDomainOptionViewModel SolutionDomainTypeOptionVm
-    {
-        get;
-        set
-        {
-            field = value;
-            OnPropertyChanged(nameof(SolutionDomainTypeOptionVm));
-        }
-    }
-
-    public RangeViewModel[] AllRangeVMs
-    {
-        get => _allRangeVMs;
-        set
-        {
-            _allRangeVMs = value;
-            OnPropertyChanged(nameof(AllRangeVMs));
-        }
-    }
 
     public OptionViewModel<ForwardSolverType> MeasuredForwardSolverTypeOptionVm
     {
@@ -224,26 +124,6 @@ public class InverseSolverViewModel : BindableObject
         {
             field = value;
             OnPropertyChanged(nameof(MeasuredOpticalPropertyVm));
-        }
-    }
-
-    public bool UseSpectralPanelData // for measured data
-    {
-        get => _useSpectralPanelData;
-        set
-        {
-            _useSpectralPanelData = value;
-            OnPropertyChanged(nameof(UseSpectralPanelData));
-        }
-    }
-
-    public bool ShowOpticalProperties // for measured data
-    {
-        get => _showOpticalProperties;
-        set
-        {
-            _showOpticalProperties = value;
-            OnPropertyChanged(nameof(ShowOpticalProperties));
         }
     }
 
@@ -361,11 +241,11 @@ public class InverseSolverViewModel : BindableObject
                 break;
         }
 
-        var isWavelengthPlot = _allRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
-        if (_allRangeVMs.Length <= 1) return [solverString + modelString + (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString)];
+        var isWavelengthPlot = AllRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
+        if (AllRangeVMs.Length <= 1) return [solverString + modelString + (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString)];
         var secondaryRangeVm = isWavelengthPlot
-            ? _allRangeVMs.First(vm => vm.AxisType != IndependentVariableAxis.Wavelength)
-            : _allRangeVMs.First(
+            ? AllRangeVMs.First(vm => vm.AxisType != IndependentVariableAxis.Wavelength)
+            : AllRangeVMs.First(
                 vm => vm.AxisType != IndependentVariableAxis.Time && 
                       vm.AxisType != IndependentVariableAxis.Ft);
 
@@ -376,7 +256,8 @@ public class InverseSolverViewModel : BindableObject
                 .ToArray();
         return
             [.. secondaryAxesStrings.Select(
-                    sas => solverString + modelString + sas + (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString))];
+                    sas => solverString + modelString + sas + 
+                           (isWavelengthPlot ? "\r" + StringLookup.GetLocalizedString("Label_SpectralMuAMuSPrime") : opString))];
     }
 
     private PlotAxesLabels GetPlotLabels()
@@ -400,19 +281,22 @@ public class InverseSolverViewModel : BindableObject
         var plotLabels = GetLegendLabels(PlotDataType.Guess);
         var plotData = initialGuessDataPoints.Zip(plotLabels, (p, el) => new PlotData(p, el)).ToArray();
         WindowViewModel.Current.PlotVm.PlotValues.Execute(plotData);
-        WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(StringLookup.GetLocalizedString("Label_InitialGuess") +
-                                                                            InitialGuessOpticalPropertyVm + " \r");
+        WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(
+            StringLookup.GetLocalizedString("Label_InitialGuess") +
+            InitialGuessOpticalPropertyVm + " \r");
     }
 
     private void SolveInverseCommand_Executed()
     {
         // Report inverse solver setup and results
-        WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(StringLookup.GetLocalizedString("Label_InverseSolutionResults") + "\r");
-        WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute("   " + StringLookup.GetLocalizedString("Label_OptimizationParameter") +
-                                                                            InverseFitTypeOptionVm.SelectedValue +
-                                                                            " \r");
-        WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute("   " + StringLookup.GetLocalizedString("Label_InitialGuess") +
-                                                                            InitialGuessOpticalPropertyVm + " \r");
+        WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(
+            StringLookup.GetLocalizedString("Label_InverseSolutionResults") + "\r");
+        WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(
+            "   " + StringLookup.GetLocalizedString("Label_OptimizationParameter") +
+            InverseFitTypeOptionVm.SelectedValue + " \r");
+        WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(
+            "   " + StringLookup.GetLocalizedString("Label_InitialGuess") +
+            InitialGuessOpticalPropertyVm + " \r");
 
         var inverseResult = SolveInverse();
         ResultOpticalPropertyVm.SetOpticalProperties(inverseResult.FitOpticalProperties[0]);
@@ -430,10 +314,11 @@ public class InverseSolverViewModel : BindableObject
             var wavelengths = GetParameterValues(IndependentVariableAxis.Wavelength);
             var wvUnitString = IndependentVariableAxisUnits.NM.GetInternationalizedString();
             var opUnitString = StringLookup.GetLocalizedString("Measurement_Inv_mm");
-            var sb =
-                new StringBuilder("\t[" + StringLookup.GetLocalizedString("Label_Wavelength") + " (" + wvUnitString +
-                                  ")]\t\t\t\t\t\t[" + StringLookup.GetLocalizedString("Label_Exact") + "]\t\t\t\t\t\t[" + 
-                                  StringLookup.GetLocalizedString("Label_ConvergedValues") + "]\t\t\t\t\t\t[" + StringLookup.GetLocalizedString("Label_Units") + "]\r");
+            var sb = new StringBuilder("\t[" + StringLookup.GetLocalizedString("Label_Wavelength") + 
+                                       " (" + wvUnitString + ")]\t\t\t\t\t\t[" + 
+                                       StringLookup.GetLocalizedString("Label_Exact") + "]\t\t\t\t\t\t[" + 
+                                       StringLookup.GetLocalizedString("Label_ConvergedValues") + "]\t\t\t\t\t\t[" + 
+                                       StringLookup.GetLocalizedString("Label_Units") + "]\r");
             for (var i = 0; i < fitOPs.Length; i++)
             {
                 sb.Append("\t" + wavelengths[i] + "\t\t\t\t\t\t" + measuredOPs[i] + "\t\t\t" + fitOPs[i] + "\t\t\t" +
@@ -443,11 +328,13 @@ public class InverseSolverViewModel : BindableObject
         }
         else
         {
-            WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute("   " + StringLookup.GetLocalizedString("Label_Exact") + ": " +
-                                                                                MeasuredOpticalPropertyVm + " \r");
-            WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute("   " + StringLookup.GetLocalizedString("Label_ConvergedValues") + ": " +
-                                                                                ResultOpticalPropertyVm + " \r");
-                            //Display Percent Error
+            WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(
+                "   " + StringLookup.GetLocalizedString("Label_Exact") + 
+                ": " + MeasuredOpticalPropertyVm + " \r");
+            WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(
+                "   " + StringLookup.GetLocalizedString("Label_ConvergedValues") + 
+                ": " + ResultOpticalPropertyVm + " \r");
+            //Display Percent Error
             var muaError = 0.0;
             var muspError = 0.0;
             if (MeasuredOpticalPropertyVm.Mua > 0)
@@ -460,9 +347,11 @@ public class InverseSolverViewModel : BindableObject
                 var tempMuspError = (int)(10000.0 * Math.Abs(ResultOpticalPropertyVm.Musp - MeasuredOpticalPropertyVm.Musp) / MeasuredOpticalPropertyVm.Musp);
                 muspError = tempMuspError / 100.0;
             }
-            WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute("   " + StringLookup.GetLocalizedString("Label_PercentError") + 
-                                                                                StringLookup.GetLocalizedString("Label_MuA") + " = " + muaError +
-                                                                                "%  " + StringLookup.GetLocalizedString("Label_MuSPrime") + " = " + muspError + "% \r");
+            WindowViewModel.Current.TextOutputVm.TextOutputPostMessage.Execute(
+                "   " + StringLookup.GetLocalizedString("Label_PercentError") + 
+                StringLookup.GetLocalizedString("Label_MuA") + " = " + muaError +
+                "%  " + StringLookup.GetLocalizedString("Label_MuSPrime") + 
+                " = " + muspError + "% \r");
         }
 
         var axesLabels = GetPlotLabels();
@@ -592,9 +481,9 @@ public class InverseSolverViewModel : BindableObject
 
     private IDataPoint[][] GetDataPoints(double[] reflectance)
     {
-        var plotIsVsWavelength = _allRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
+        var plotIsVsWavelength = AllRangeVMs.Any(vm => vm.AxisType == IndependentVariableAxis.Wavelength);
         var isComplexPlot = ComputationFactory.IsComplexSolver(SolutionDomainTypeOptionVm.SelectedValue);
-        var primaryIndependentValues = _allRangeVMs[0].Values.ToArray();
+        var primaryIndependentValues = AllRangeVMs[0].Values.ToArray();
         var numPointsPerCurve = primaryIndependentValues.Length;
         var numForwardValues = isComplexPlot ? reflectance.Length/2 : reflectance.Length;
         // complex reported as all real numbers, then all imaginary numbers
@@ -645,24 +534,6 @@ public class InverseSolverViewModel : BindableObject
             EnumerableExtensions.ToDictionary(returnValue);
     }
 
-    /// <summary>
-    ///     Function to provide ordering information for assembling forward calls
-    /// </summary>
-    /// <param name="axis"></param>
-    /// <returns></returns>
-    private static int GetParameterOrder(IndependentVariableAxis axis)
-    {
-        return axis switch
-        {
-            IndependentVariableAxis.Wavelength => 0,
-            IndependentVariableAxis.Rho => 1,
-            IndependentVariableAxis.Fx => 1,
-            IndependentVariableAxis.Time => 2,
-            IndependentVariableAxis.Ft => 2,
-            IndependentVariableAxis.Z => 3,
-            _ => throw new ArgumentOutOfRangeException(nameof(axis))
-        };
-    }
 
     private double[] GetParameterValues(IndependentVariableAxis axis)
     {

--- a/Vts.Gui.Wpf/ViewModel/Panels/InverseSolverViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/InverseSolverViewModel.cs
@@ -1,12 +1,13 @@
-﻿using System;
+﻿using CommunityToolkit.Mvvm.Input;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text;
-using CommunityToolkit.Mvvm.Input;
 using Vts.Extensions;
 using Vts.Factories;
 using Vts.Gui.Wpf.Extensions;
+using Vts.Gui.Wpf.Helpers;
 using Vts.Gui.Wpf.Model;
 using Vts.Gui.Wpf.Resources;
 using Vts.Gui.Wpf.ViewModel.Controls;
@@ -42,25 +43,31 @@ public class InverseSolverViewModel : BindableObject
                 AllowMultiAxis = false
             };
 
-        void UpdateSolutionDomainWithWavelength(double wv)
-        {
-            var wvAxis = SolutionDomainTypeOptionVm.ConstantAxesVMs.FirstOrDefault(axis => axis.AxisType == IndependentVariableAxis.Wavelength);
-            wvAxis?.AxisValue = wv;
-        }
-
         SolutionDomainTypeOptionVm.PropertyChanged += (_, args) =>
         {
+            var useSpectralPanelDataAndNotNull = SolutionDomainTypeOptionVm.UseSpectralInputs &&
+                                                 WindowViewModel.Current != null &&
+                                                 WindowViewModel.Current.SpectralMappingVm != null;
+
             switch (args.PropertyName)
             {
+                case "ConstantAxesVMs":
+                    // update solution domain wavelength constant if applicable
+                    if (useSpectralPanelDataAndNotNull &&
+                        WindowViewModel.Current != null &&
+                        SolutionDomainTypeOptionVm.ConstantAxesVMs.Any(
+                            axis => axis.AxisType == IndependentVariableAxis.Wavelength))
+                    {
+
+                        WindowViewModel.Current.SpectralMappingVm.Wavelength = SolutionDomainTypeOptionVm.ConstantAxesVMs
+                            .First(axis => axis.AxisType == IndependentVariableAxis.Wavelength).AxisValue;
+                    }
+                    break;
                 case "UseSpectralInputs":
                     UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
                     break;
                 case "IndependentAxesVMs":
                 {
-                    var useSpectralPanelDataAndNotNull = UseSpectralPanelData && 
-                                                         WindowViewModel.Current != null &&
-                                                         WindowViewModel.Current.SpectralMappingVm != null;
-
                     AllRangeVMs =
                         (from i in
                                 Enumerable.Range(0,
@@ -122,41 +129,26 @@ public class InverseSolverViewModel : BindableObject
         CalculateInitialGuessCommand = new RelayCommand(CalculateInitialGuessCommand_Executed);
         SolveInverseCommand = new RelayCommand(SolveInverseCommand_Executed);
 
-        if (WindowViewModel.Current.SpectralMappingVm != null)
+        MeasuredOpticalPropertyVm.PropertyChanged += (_, _) =>
         {
-            WindowViewModel.Current.SpectralMappingVm.PropertyChanged += (_, args) =>
+            //need to get the value from the checkbox in case UseSpectralPanelData has not yet been updated
+            if (SolutionDomainTypeOptionVm != null)
             {
-                if (args.PropertyName == "Wavelength")
-                {
-                    //need to get the value from the checkbox in case UseSpectralPanelData has not yet been updated
-                    if (SolutionDomainTypeOptionVm != null)
-                    {
-                        UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
-                    }
-                    if (UseSpectralPanelData && WindowViewModel.Current != null &&
-                        WindowViewModel.Current.SpectralMappingVm != null)
-                    {
-                        UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
-                    }
-                }
-
-                if (args.PropertyName == "OpticalProperties")
-                {
-                    //need to get the value from the checkbox in case UseSpectralPanelData has not yet been updated
-                    if (SolutionDomainTypeOptionVm != null)
-                    {
-                        UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
-                    }
-                    if (UseSpectralPanelData && WindowViewModel.Current != null &&
-                        WindowViewModel.Current.SpectralMappingVm != null &&
-                        MeasuredOpticalPropertyVm != null)
-                    {
-                        MeasuredOpticalPropertyVm.SetOpticalProperties(
-                            WindowViewModel.Current.SpectralMappingVm.OpticalProperties);
-                    }
-                    
-                }
-            };
+                UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
+            }
+            if (UseSpectralPanelData && WindowViewModel.Current != null &&
+                WindowViewModel.Current.SpectralMappingVm != null)
+            {
+                UpdateSolutionDomainWithWavelength(WindowViewModel.Current.SpectralMappingVm.Wavelength);
+            }
+        };
+    }
+    private void UpdateSolutionDomainWithWavelength(double wv)
+    {
+        var wvAxis = SolutionDomainTypeOptionVm.ConstantAxesVMs.FirstOrDefault(axis => axis.AxisType == IndependentVariableAxis.Wavelength);
+        if (wvAxis != null && !Calculations.AreApproximatelyEqual(wvAxis.AxisValue, wv))
+        {
+            wvAxis.AxisValue = wv;
         }
     }
 
@@ -287,6 +279,20 @@ public class InverseSolverViewModel : BindableObject
     public IForwardSolver InverseForwardSolver => SolverFactory.GetForwardSolver(InverseForwardSolverTypeOptionVm.SelectedValue);
 
     public IOptimizer Optimizer => SolverFactory.GetOptimizer(OptimizerTypeOptionVm.SelectedValue);
+
+    public void UpdateOpticalProperties_Executed()
+    {
+        //need to get the value from the checkbox in case UseSpectralPanelData has not yet been updated
+        if (SolutionDomainTypeOptionVm != null)
+        {
+            UseSpectralPanelData = SolutionDomainTypeOptionVm.UseSpectralInputs;
+        }
+
+        if (!UseSpectralPanelData || WindowViewModel.Current == null ||
+            WindowViewModel.Current.SpectralMappingVm == null) return;
+        InitialGuessOpticalPropertyVm?.SetOpticalProperties(WindowViewModel.Current.SpectralMappingVm.OpticalProperties);
+        MeasuredOpticalPropertyVm?.SetOpticalProperties(WindowViewModel.Current.SpectralMappingVm.OpticalProperties);
+    }
 
     private void SimulateMeasuredDataCommand_Executed()
     {

--- a/Vts.Gui.Wpf/ViewModel/Panels/SpectralMappingViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/SpectralMappingViewModel.cs
@@ -252,6 +252,7 @@ public class SpectralMappingViewModel : BindableObject
         OnPropertyChanged(nameof(N));
         OnPropertyChanged(nameof(OpticalProperties));
         WindowViewModel.Current.ForwardSolverVm.UpdateOpticalProperties_Executed();
+        WindowViewModel.Current.InverseSolverVm.UpdateOpticalProperties_Executed();
     }
 
     private void ResetConcentrations_Executed(object obj)

--- a/Vts.Gui.Wpf/ViewModel/Panels/SubPanels/ConstantAxisViewModel.cs
+++ b/Vts.Gui.Wpf/ViewModel/Panels/SubPanels/ConstantAxisViewModel.cs
@@ -1,6 +1,4 @@
-﻿using Vts.Gui.Wpf.Input;
-
-namespace Vts.Gui.Wpf.ViewModel.Panels.SubPanels;
+﻿namespace Vts.Gui.Wpf.ViewModel.Panels.SubPanels;
 
 public class ConstantAxisViewModel : BindableObject
 {
@@ -40,12 +38,6 @@ public class ConstantAxisViewModel : BindableObject
         set
         {
             field = value;
-            if (AxisType == IndependentVariableAxis.Wavelength)
-            {
-                // update the world that this has changed, and react to it if desired (e.g. in Spectral Panel)
-                Commands.SetWavelength.Execute(AxisValue, null);
-            }
-
             OnPropertyChanged(nameof(AxisValue));
         }
     }


### PR DESCRIPTION
I removed the spectral panel inputs checkbox from the inverse panel but I left the code in place that updates the wavelength and the optical properties to the spectral values in case we add that code back in later.